### PR TITLE
Fixed package structure for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,7 @@ yarn test
 
 # test w/ reloading
 yarn test:watch
+
+# publish (run this script instead of npm publish!)
+./publish.sh
 ```

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
   "name": "keystore-idb",
-  "version": "0.3.2",
+  "version": "0.4.2",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
-  "main": "dist/index.umd.js",
-  "module": "dist/index.es5.js",
-  "typings": "dist/types/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "main": "index.umd.js",
+  "module": "index.es5.js",
+  "typings": "types/index.d.ts",
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {
     "type": "git",

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,6 @@
+yarn build
+cp ./package.json dist/
+cp ./README.md dist/
+cp ./LICENSE dist/
+cd dist
+npm publish

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -9,8 +9,8 @@ const pkg = require('./package.json')
 export default {
   input: `src/index.ts`,
   output: [
-    { file: pkg.main, name: 'index', format: 'umd', sourcemap: true },
-    { file: pkg.module, format: 'es', sourcemap: true },
+    { file: `dist/${pkg.main}`, name: 'index', format: 'umd', sourcemap: true },
+    { file: `dist/${pkg.module}`, format: 'es', sourcemap: true },
   ],
   // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
   external: [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/lib",
+    "declarationDir": "dist",
+    "outDir": "dist",
     "typeRoots": [
       "node_modules/@types",
       "src/@types"


### PR DESCRIPTION
## Problem
Paths for relative imports are longwinded (`keystore/dist/types/types`)

## Solution
- Put all compiler output in `dist` (instead of `lib` & `types`)
- add publish script to copy necessary files over to `dist` and publish from within the folder
