### PR TITLE
Expanded AES

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       }
     },
     "collectCoverageFrom": [
-      "src/*.{js,ts}"
+      "src/**/*.{js,ts}"
     ],
     "globals": {
       "window": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystore-idb",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "main": "index.umd.js",

--- a/src/aes/index.ts
+++ b/src/aes/index.ts
@@ -1,42 +1,10 @@
-import utils from '../utils'
-import { DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
-import { SymmKey, SymmKeyOpts, SymmAlg, CipherText } from '../types'
+import keys from './keys'
+import operations from './operations'
 
-export async function encrypt(data: ArrayBuffer, key: SymmKey, opts?: Partial<SymmKeyOpts>): Promise<CipherText> {
-  const alg = opts?.alg || DEFAULT_SYMM_ALG
-  const iv = opts?.iv || utils.randomBuf(16)
-  const cipherBuf = await window.crypto.subtle.encrypt(
-    { 
-      name: alg,
-      length: opts?.length || DEFAULT_SYMM_LEN,
-      // AES-CTR uses a counter, AES-GCM/AES-CBC use an initialization vector
-      iv: alg === SymmAlg.AES_CTR ? undefined : iv,
-      counter: alg === SymmAlg.AES_CTR ? new Uint8Array(iv) : undefined,
-    },
-    key,
-    data
-  )
-  return utils.joinBufs(iv, cipherBuf)
-}
-
-export async function decrypt(cipherText: CipherText, key: SymmKey, opts?: Partial<SymmKeyOpts>): Promise<ArrayBuffer> {
-  const alg = opts?.alg || DEFAULT_SYMM_ALG
-  const iv = cipherText.slice(0, 16)
-  const cipherBytes = cipherText.slice(16)
-  const msgBuff = await window.crypto.subtle.decrypt(
-    { name: alg,
-      length: opts?.length || DEFAULT_SYMM_LEN,
-      // AES-CTR uses a counter, AES-GCM/AES-CBC use an initialization vector
-      iv: alg === SymmAlg.AES_CTR ? undefined : iv,
-      counter: alg === SymmAlg.AES_CTR ? new Uint8Array(iv) : undefined,
-    },
-    key,
-    cipherBytes
-  )
-  return msgBuff
-}
+export * from './keys'
+export * from './operations'
 
 export default {
-  decrypt,
-  encrypt
+  ...keys,
+  ...operations,
 }

--- a/src/aes/keys.ts
+++ b/src/aes/keys.ts
@@ -1,0 +1,33 @@
+import utils from '../utils'
+import { DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
+import { SymmKey, SymmKeyOpts } from '../types'
+
+export async function makeKey(opts?: Partial<SymmKeyOpts>): Promise<SymmKey> {
+  return window.crypto.subtle.generateKey(
+    { 
+      name: opts?.alg || DEFAULT_SYMM_ALG,
+      length: opts?.length || DEFAULT_SYMM_LEN,
+    },
+    true,
+    ['encrypt', 'decrypt']
+  )
+}
+
+export async function importKey(base64key: string, opts?: Partial<SymmKeyOpts>): Promise<SymmKey> {
+  const buf = utils.base64ToArrBuf(base64key)
+  return window.crypto.subtle.importKey(
+    'raw',
+    buf,
+    { 
+      name: opts?.alg || DEFAULT_SYMM_ALG,
+      length: opts?.length || DEFAULT_SYMM_LEN,
+    },
+    true,
+    ['encrypt', 'decrypt']
+  )
+}
+
+export default {
+  makeKey,
+  importKey
+}

--- a/src/aes/operations.ts
+++ b/src/aes/operations.ts
@@ -45,10 +45,10 @@ export async function encrypt(msg: string, key: string, opts?: Partial<SymmKeyOp
 }
 
 export async function decrypt(cipherText: string, key: string, opts?: Partial<SymmKeyOpts>): Promise<string> {
-  const buf = utils.strToArrBuf(cipherText, 16)
+  const buf = utils.base64ToArrBuf(cipherText)
   const cipherKey = await keys.importKey(key, opts)
   const msgBytes = await decryptBytes(buf, cipherKey, opts)
-  return utils.arrBufToBase64(msgBytes)
+  return utils.arrBufToStr(msgBytes, 16)
 }
 
 export async function exportKey(key: SymmKey): Promise<string> {

--- a/src/aes/operations.ts
+++ b/src/aes/operations.ts
@@ -1,0 +1,65 @@
+import keys from './keys'
+import utils from '../utils'
+import { DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
+import { SymmKey, SymmKeyOpts, SymmAlg, CipherText } from '../types'
+
+export async function encryptBytes(data: ArrayBuffer, key: SymmKey, opts?: Partial<SymmKeyOpts>): Promise<CipherText> {
+  const alg = opts?.alg || DEFAULT_SYMM_ALG
+  const iv = opts?.iv || utils.randomBuf(16)
+  const cipherBuf = await window.crypto.subtle.encrypt(
+    { 
+      name: alg,
+      length: opts?.length || DEFAULT_SYMM_LEN,
+      // AES-CTR uses a counter, AES-GCM/AES-CBC use an initialization vector
+      iv: alg === SymmAlg.AES_CTR ? undefined : iv,
+      counter: alg === SymmAlg.AES_CTR ? new Uint8Array(iv) : undefined,
+    },
+    key,
+    data
+  )
+  return utils.joinBufs(iv, cipherBuf)
+}
+
+export async function decryptBytes(cipherText: CipherText, key: SymmKey, opts?: Partial<SymmKeyOpts>): Promise<ArrayBuffer> {
+  const alg = opts?.alg || DEFAULT_SYMM_ALG
+  const iv = cipherText.slice(0, 16)
+  const cipherBytes = cipherText.slice(16)
+  const msgBuff = await window.crypto.subtle.decrypt(
+    { name: alg,
+      length: opts?.length || DEFAULT_SYMM_LEN,
+      // AES-CTR uses a counter, AES-GCM/AES-CBC use an initialization vector
+      iv: alg === SymmAlg.AES_CTR ? undefined : iv,
+      counter: alg === SymmAlg.AES_CTR ? new Uint8Array(iv) : undefined,
+    },
+    key,
+    cipherBytes
+  )
+  return msgBuff
+}
+
+export async function encrypt(msg: string, key: string, opts?: Partial<SymmKeyOpts>): Promise<string> {
+  const buf = utils.strToArrBuf(msg, 16)
+  const cipherKey = await keys.importKey(key, opts)
+  const cipherText = await encryptBytes(buf, cipherKey, opts)
+  return utils.arrBufToBase64(cipherText)
+}
+
+export async function decrypt(cipherText: string, key: string, opts?: Partial<SymmKeyOpts>): Promise<string> {
+  const buf = utils.strToArrBuf(cipherText, 16)
+  const cipherKey = await keys.importKey(key, opts)
+  const msgBytes = await decryptBytes(buf, cipherKey, opts)
+  return utils.arrBufToBase64(msgBytes)
+}
+
+export async function exportKey(key: SymmKey): Promise<string> {
+  const raw = await window.crypto.subtle.exportKey('raw', key)
+  return utils.arrBufToBase64(raw)
+}
+
+export default {
+  encryptBytes,
+  decryptBytes,
+  encrypt,
+  decrypt,
+  exportKey
+}

--- a/src/ecc/keys.ts
+++ b/src/ecc/keys.ts
@@ -34,12 +34,12 @@ export async function getKey(
   return keypair
 }
 
-export async function importPublicKey(hexKey: string, curve: EccCurve, use: KeyUse): Promise<PublicKey> {
+export async function importPublicKey(base64Key: string, curve: EccCurve, use: KeyUse): Promise<PublicKey> {
   checkValidKeyUse(use)
   const alg = use === KeyUse.Read ? ECC_READ_ALG : ECC_WRITE_ALG
   const uses =
     use === KeyUse.Read ? [] : ['verify']
-  const buf = utils.base64ToArrBuf(hexKey)
+  const buf = utils.base64ToArrBuf(base64Key)
   return window.crypto.subtle.importKey(
     'raw',
     buf,

--- a/src/ecc/operations.ts
+++ b/src/ecc/operations.ts
@@ -35,12 +35,12 @@ export async function getSharedKey(privateKey: PrivateKey, publicKey: PublicKey,
 
 export async function encryptBytes(data: ArrayBuffer, privateKey: PrivateKey, publicKey: PublicKey, opts?: Partial<SymmKeyOpts>): Promise<CipherText> {
   const cipherKey = await getSharedKey(privateKey, publicKey, opts)
-  return aes.encrypt(data, cipherKey, opts)
+  return aes.encryptBytes(data, cipherKey, opts)
 }
 
 export async function decryptBytes(cipherText: CipherText, privateKey: PrivateKey, publicKey: PublicKey, opts?: Partial<SymmKeyOpts>): Promise<ArrayBuffer> {
   const cipherKey = await getSharedKey(privateKey, publicKey, opts)
-  return aes.decrypt(cipherText, cipherKey, opts)
+  return aes.decryptBytes(cipherText, cipherKey, opts)
 }
 
 export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {

--- a/src/rsa/keys.ts
+++ b/src/rsa/keys.ts
@@ -40,17 +40,17 @@ export async function getKey(
   return keypair
 }
 
-function stripKeyHeader(hexKey: string): string{
-  return hexKey
+function stripKeyHeader(base64Key: string): string{
+  return base64Key
     .replace('-----BEGIN PUBLIC KEY-----\n', '')
     .replace('\n-----END PUBLIC KEY-----', '')
 }
 
-export async function importPublicKey(hexKey: string, hashAlg: HashAlg, use: KeyUse): Promise<PublicKey> {
+export async function importPublicKey(base64Key: string, hashAlg: HashAlg, use: KeyUse): Promise<PublicKey> {
   checkValidKeyUse(use)
   const alg = use === KeyUse.Read ? RSA_READ_ALG : RSA_WRITE_ALG
   const uses = use === KeyUse.Read ? ['encrypt'] : ['verify']
-  const buf = utils.base64ToArrBuf(stripKeyHeader(hexKey))
+  const buf = utils.base64ToArrBuf(stripKeyHeader(base64Key))
   return window.crypto.subtle.importKey(
     'spki',
     buf,

--- a/test/aes.test.ts
+++ b/test/aes.test.ts
@@ -1,0 +1,164 @@
+import aes from '../src/aes'
+import errors from '../src/errors'
+import utils from '../src/utils'
+import { KeyUse, EccCurve, HashAlg, SymmAlg, SymmKeyLength } from '../src/types'
+import { mock, cryptoMethod, idbMethod, arrBufEq } from './utils'
+
+const sinon = require('sinon')
+
+describe('aes', () => {
+
+  beforeEach(() => sinon.restore())
+
+  cryptoMethod({
+    desc: 'makeKey',
+    setMock: fake => window.crypto.subtle.generateKey = fake,
+    mockResp: mock.symmKey,
+    simpleReq: () => aes.makeKey(),
+    simpleParams: [
+      { name: 'AES-CTR', length: 128 },
+      true,
+      [ 'encrypt', 'decrypt']
+    ],
+    paramChecks: [
+      {
+        desc: 'handles multiple key algorithms',
+        req: () => aes.makeKey({ alg: SymmAlg.AES_CBC }),
+        params: (params: any) => params[0]?.name === 'AES-CBC'
+      },
+      {
+        desc: 'handles multiple key lengths',
+        req: () => aes.makeKey({ length: SymmKeyLength.B256 }),
+        params: (params: any) => params[0]?.length === 256
+      }
+    ],
+    shouldThrows: [ ]
+  })
+
+  cryptoMethod({
+    desc: 'importKey',
+    setMock: fake => window.crypto.subtle.importKey = fake,
+    mockResp: mock.symmKey,
+    simpleReq: () => aes.importKey(mock.keyBase64),
+    simpleParams: [
+      'raw',
+      utils.base64ToArrBuf(mock.keyBase64),
+      { name: 'AES-CTR', length: 128 },
+      true,
+      [ 'encrypt', 'decrypt']
+    ],
+    paramChecks: [
+      {
+        desc: 'handles multiple key algorithms',
+        req: () => aes.importKey(mock.keyBase64, { alg: SymmAlg.AES_CBC }),
+        params: (params: any) => params[2]?.name === 'AES-CBC'
+      },
+      {
+        desc: 'handles multiple key lengths',
+        req: () => aes.importKey(mock.keyBase64, { length: SymmKeyLength.B256 }),
+        params: (params: any) => params[2]?.length === 256
+      }
+    ],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'encrypt',
+    setMock: fake => {
+      window.crypto.subtle.encrypt = fake
+      window.crypto.subtle.importKey = sinon.fake.returns(new Promise(r => r(mock.symmKey)))
+      window.crypto.getRandomValues = sinon.fake.returns(new Promise(r => r()))
+    },
+    mockResp: mock.cipherBytes,
+    expectedResp: mock.cipherWithIVStr,
+    simpleReq: () => aes.encrypt(mock.msgStr, mock.keyBase64, { iv: mock.iv }),
+    paramChecks: [
+      {
+        desc: 'correctly passes params with AES-CTR',
+        req: () => aes.encrypt(mock.msgStr, mock.keyBase64, { iv: mock.iv }),
+        params: (params: any) => (
+          params[0]?.name === 'AES-CTR'
+          && params[0]?.length === 128
+          && arrBufEq(params[0]?.counter, mock.iv)
+          && params[1] === mock.symmKey
+          && arrBufEq(params[2], mock.msgBytes)
+        )
+      },
+      {
+        desc: 'correctly passes params with AES-CBC',
+        req: () => aes.encrypt(mock.msgStr, mock.keyBase64, { alg: SymmAlg.AES_CBC, iv: mock.iv }),
+        params: (params: any) => (
+          params[0]?.name === 'AES-CBC'
+          && params[0]?.length === 128
+          && arrBufEq(params[0]?.iv, mock.iv)
+          && params[1] === mock.symmKey
+          && arrBufEq(params[2], mock.msgBytes)
+        )
+      },
+      {
+        desc: 'handles multiple symm key lengths',
+        req: () => aes.encrypt(mock.msgStr, mock.keyBase64, { length: SymmKeyLength.B256}),
+        params: (params: any) => params[0]?.length === 256
+      }
+    ],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'decrypt',
+    setMock: fake => {
+      window.crypto.subtle.decrypt = fake
+      window.crypto.subtle.importKey = sinon.fake.returns(new Promise(r => r(mock.symmKey)))
+    },
+    mockResp: mock.msgBytes,
+    expectedResp: mock.msgStr,
+    simpleReq: () => aes.decrypt(mock.cipherWithIVStr, mock.keyBase64),
+    paramChecks: [
+      {
+        desc: 'correctly passes params with AES-CTR',
+        req: () => aes.decrypt(mock.cipherWithIVStr, mock.keyBase64),
+        params: (params: any) => (
+          params[0].name === 'AES-CTR'
+          && params[0].length === 128 
+          && arrBufEq(params[0].counter.buffer, mock.iv)
+          && params[1] === mock.symmKey 
+          && arrBufEq(params[2], mock.cipherBytes)
+        )
+      },
+      {
+        desc: 'correctly passes params with AES-CBC',
+        req: () => aes.decrypt(mock.cipherWithIVStr, mock.keyBase64, { alg: SymmAlg.AES_CBC }),
+        params: (params: any) => (
+          params[0]?.name === 'AES-CBC'
+          && arrBufEq(params[0].iv, mock.iv)
+          && arrBufEq(params[2], mock.cipherBytes)
+        )
+      },
+      {
+        desc: 'handles multiple symm key lengths',
+        req: () => aes.decrypt(mock.cipherWithIVStr, mock.keyBase64, { length: SymmKeyLength.B256 }),
+        params: (params: any) => params[0]?.length === 256
+      },
+    ],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'exportKey',
+    setMock: fake => window.crypto.subtle.exportKey = fake,
+    mockResp: utils.base64ToArrBuf(mock.keyBase64),
+    expectedResp: mock.keyBase64,
+    simpleReq: () => aes.exportKey(mock.symmKey),
+    simpleParams: [
+      'raw',
+      mock.symmKey
+    ],
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+})

--- a/test/ecc.keystore.test.ts
+++ b/test/ecc.keystore.test.ts
@@ -54,7 +54,7 @@ describe("ECCKeyStore", () => {
       {
         mod: operations,
         meth: 'signBytes', 
-        resp: mock.signature,
+        resp: mock.sigBytes,
         params: [
           mock.msgBytes,
           mock.writeKeys.privateKey,
@@ -63,7 +63,7 @@ describe("ECCKeyStore", () => {
       }
     ],
     reqFn: (ks) => ks.sign(mock.msgStr),
-    expectedResp: mock.signatureStr,
+    expectedResp: mock.sigStr,
   })
 
 
@@ -77,7 +77,7 @@ describe("ECCKeyStore", () => {
         resp: true,
         params: [
           mock.msgBytes,
-          mock.signature,
+          mock.sigBytes,
           mock.writeKeys.publicKey,
           config.defaultConfig.hashAlg
         ]
@@ -87,13 +87,13 @@ describe("ECCKeyStore", () => {
         meth: 'importPublicKey',
         resp: mock.writeKeys.publicKey,
         params: [
-          mock.publicKeyBase64,
+          mock.keyBase64,
           config.defaultConfig.curve,
           KeyUse.Write
         ]
       }
     ],
-    reqFn: (ks) => ks.verify(mock.msgStr, mock.signatureStr, mock.publicKeyBase64),
+    reqFn: (ks) => ks.verify(mock.msgStr, mock.sigStr, mock.keyBase64),
     expectedResp: true,
   })
 
@@ -105,7 +105,7 @@ describe("ECCKeyStore", () => {
       {
         mod: operations,
         meth: 'encryptBytes', 
-        resp: mock.cipherText,
+        resp: mock.cipherBytes,
         params: [
           mock.msgBytes,
           mock.keys.privateKey,
@@ -118,14 +118,14 @@ describe("ECCKeyStore", () => {
         meth: 'importPublicKey',
         resp: mock.encryptForKey.publicKey,
         params: [
-          mock.publicKeyBase64,
+          mock.keyBase64,
           config.defaultConfig.curve,
           KeyUse.Read
         ]
       }
     ],
-    reqFn: (ks) => ks.encrypt(mock.msgStr, mock.publicKeyBase64),
-    expectedResp: mock.cipherTextStr,
+    reqFn: (ks) => ks.encrypt(mock.msgStr, mock.keyBase64),
+    expectedResp: mock.cipherStr,
   })
 
 
@@ -138,7 +138,7 @@ describe("ECCKeyStore", () => {
         meth: 'decryptBytes', 
         resp: mock.msgBytes,
         params: [
-          mock.cipherText,
+          mock.cipherBytes,
           mock.keys.privateKey,
           mock.encryptForKey.publicKey,
           config.defaultConfig.symmAlg
@@ -149,13 +149,13 @@ describe("ECCKeyStore", () => {
         meth: 'importPublicKey',
         resp: mock.encryptForKey.publicKey,
         params: [
-          mock.publicKeyBase64,
+          mock.keyBase64,
           config.defaultConfig.curve,
           KeyUse.Read
         ]
       }
     ],
-    reqFn: (ks) => ks.decrypt(mock.cipherTextStr, mock.publicKeyBase64),
+    reqFn: (ks) => ks.decrypt(mock.cipherStr, mock.keyBase64),
     expectedResp: mock.msgStr,
   })
 
@@ -167,14 +167,14 @@ describe("ECCKeyStore", () => {
       {
         mod: operations,
         meth: 'getPublicKey', 
-        resp: mock.publicKeyBase64,
+        resp: mock.keyBase64,
         params: [
           mock.keys
         ]
       }
     ],
     reqFn: (ks) => ks.publicReadKey(),
-    expectedResp: mock.publicKeyBase64,
+    expectedResp: mock.keyBase64,
   })
 
 
@@ -185,14 +185,14 @@ describe("ECCKeyStore", () => {
       {
         mod: operations,
         meth: 'getPublicKey', 
-        resp: mock.publicKeyBase64,
+        resp: mock.keyBase64,
         params: [
           mock.writeKeys
         ]
       }
     ],
     reqFn: (ks) => ks.publicWriteKey(),
-    expectedResp: mock.publicKeyBase64,
+    expectedResp: mock.keyBase64,
   })
 
 })

--- a/test/rsa.keystore.test.ts
+++ b/test/rsa.keystore.test.ts
@@ -56,7 +56,7 @@ describe("RSAKeyStore", () => {
       {
         mod: operations,
         meth: 'signBytes', 
-        resp: mock.signature,
+        resp: mock.sigBytes,
         params: [
           mock.msgBytes,
           mock.writeKeys.privateKey,
@@ -64,7 +64,7 @@ describe("RSAKeyStore", () => {
       }
     ],
     reqFn: (ks) => ks.sign(mock.msgStr),
-    expectedResp: mock.signatureStr,
+    expectedResp: mock.sigStr,
   })
 
 
@@ -78,7 +78,7 @@ describe("RSAKeyStore", () => {
         resp: true,
         params: [
           mock.msgBytes,
-          mock.signature,
+          mock.sigBytes,
           mock.writeKeys.publicKey,
         ]
       },
@@ -87,13 +87,13 @@ describe("RSAKeyStore", () => {
         meth: 'importPublicKey',
         resp: mock.writeKeys.publicKey,
         params: [
-          mock.publicKeyBase64,
+          mock.keyBase64,
           config.defaultConfig.hashAlg,
           KeyUse.Write
         ]
       }
     ],
-    reqFn: (ks) => ks.verify(mock.msgStr, mock.signatureStr, mock.publicKeyBase64),
+    reqFn: (ks) => ks.verify(mock.msgStr, mock.sigStr, mock.keyBase64),
     expectedResp: true,
   })
 
@@ -105,7 +105,7 @@ describe("RSAKeyStore", () => {
       {
         mod: operations,
         meth: 'encryptBytes', 
-        resp: mock.cipherText,
+        resp: mock.cipherBytes,
         params: [
           mock.msgBytes,
           mock.encryptForKey.publicKey,
@@ -116,14 +116,14 @@ describe("RSAKeyStore", () => {
         meth: 'importPublicKey',
         resp: mock.encryptForKey.publicKey,
         params: [
-          mock.publicKeyBase64,
+          mock.keyBase64,
           config.defaultConfig.hashAlg,
           KeyUse.Read
         ]
       }
     ],
-    reqFn: (ks) => ks.encrypt(mock.msgStr, mock.publicKeyBase64),
-    expectedResp: mock.cipherTextStr,
+    reqFn: (ks) => ks.encrypt(mock.msgStr, mock.keyBase64),
+    expectedResp: mock.cipherStr,
   })
 
 
@@ -136,12 +136,12 @@ describe("RSAKeyStore", () => {
         meth: 'decryptBytes', 
         resp: mock.msgBytes,
         params: [
-          mock.cipherText,
+          mock.cipherBytes,
           mock.keys.privateKey,
         ]
       },
     ],
-    reqFn: (ks) => ks.decrypt(mock.cipherTextStr, mock.publicKeyBase64),
+    reqFn: (ks) => ks.decrypt(mock.cipherStr, mock.keyBase64),
     expectedResp: mock.msgStr,
   })
 
@@ -153,14 +153,14 @@ describe("RSAKeyStore", () => {
       {
         mod: operations,
         meth: 'getPublicKey', 
-        resp: mock.publicKeyBase64,
+        resp: mock.keyBase64,
         params: [
           mock.keys
         ]
       }
     ],
     reqFn: (ks) => ks.publicReadKey(),
-    expectedResp: mock.publicKeyBase64,
+    expectedResp: mock.keyBase64,
   })
 
 
@@ -171,14 +171,14 @@ describe("RSAKeyStore", () => {
       {
         mod: operations,
         meth: 'getPublicKey', 
-        resp: mock.publicKeyBase64,
+        resp: mock.keyBase64,
         params: [
           mock.writeKeys
         ]
       }
     ],
     reqFn: (ks) => ks.publicWriteKey(),
-    expectedResp: mock.publicKeyBase64,
+    expectedResp: mock.keyBase64,
   })
 
 })

--- a/test/utils/mock.ts
+++ b/test/utils/mock.ts
@@ -3,7 +3,16 @@ import utils from '../../src/utils'
 window.atob = require('atob')
 window.btoa = require('btoa')
 
-const arr = new Uint8Array([1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4]) 
+const iv = (new Uint8Array([1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4])).buffer
+const msgStr = "test msg bytes"
+const msgBytes = utils.strToArrBuf(msgStr, 16)
+const sigStr = "dGVzdCBzaWduYXR1cmU="
+const sigBytes = utils.base64ToArrBuf(sigStr)
+const cipherStr = "dGVzdCBlbmNyeXB0ZWQgYnl0ZXM="
+const cipherBytes = utils.base64ToArrBuf(cipherStr)
+const cipherWithIVBytes = utils.joinBufs(iv, cipherBytes)
+const cipherWithIVStr = utils.arrBufToBase64(cipherWithIVBytes)
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const mock = {
   keys: {
@@ -19,14 +28,15 @@ export const mock = {
     privateKey: { type: 'encrypt-priv' } as any 
   } as any,
   symmKey: { type: 'symm' } as any,
-  iv: arr.buffer,
-  publicKeyBase64: 'q83vEjRWeJA=',
-  msgStr: "test msg bytes",
-  msgBytes: utils.strToArrBuf("test msg bytes", 16),
-  signatureStr: "dGVzdCBzaWduYXR1cmU=",
-  signature: utils.base64ToArrBuf("dGVzdCBzaWduYXR1cmU="),
-  cipherTextStr: "dGVzdCBlbmNyeXB0ZWQgYnl0ZXM=",
-  cipherText: utils.base64ToArrBuf("dGVzdCBlbmNyeXB0ZWQgYnl0ZXM="),
-  cipherTextWithIV: utils.joinBufs(arr.buffer, utils.base64ToArrBuf("dGVzdCBlbmNyeXB0ZWQgYnl0ZXM=")),
+  keyBase64: 'q83vEjRWeJA=',
+  iv,
+  msgStr,
+  msgBytes,
+  sigStr,
+  sigBytes,
+  cipherStr,
+  cipherBytes,
+  cipherWithIVStr,
+  cipherWithIVBytes,
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Problem
- Can't import/export raw AES keys
- AES methods take ArrayBuffers which are a pain to deal with

## Solution
- Add import/export/create methods for AES keys
- add string conversion for encrypt/decrypt