### PR TITLE
Fixed passing symm length as param

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ const defaultConfig = {
   curve: 'P-256', // 'P-256' | 'P-384' | 'P-521'
   rsaSize: 2048, // 1024 | 2048 | 4096
   symmAlg: 'AES-CTR', // 'AES-CTR' | 'AES-GCM' | 'AES-CBC'
+  symmLen: 128, // 128 | 192 | 256
   hashAlg: 'SHA-256', // 'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512'
   readKeyName: 'read-key', // any string
   writeKeyName: 'write-key', // any string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystore-idb",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "main": "index.umd.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,8 @@ import {
   DEFAULT_SYMM_ALG,
   DEFAULT_HASH_ALG,
   DEFAULT_READ_KEY_NAME,
-  DEFAULT_WRITE_KEY_NAME
+  DEFAULT_WRITE_KEY_NAME,
+  DEFAULT_SYMM_LEN
 } from './constants'
 import { Config, KeyUse, CryptoSystem } from './types'
 import utils from './utils'
@@ -16,6 +17,7 @@ export const defaultConfig = {
   curve: DEFAULT_EccCurve,
   rsaSize: DEFAULT_RsaSize,
   symmAlg: DEFAULT_SYMM_ALG,
+  symmLen: DEFAULT_SYMM_LEN,
   hashAlg: DEFAULT_HASH_ALG,
   readKeyName: DEFAULT_READ_KEY_NAME,
   writeKeyName: DEFAULT_WRITE_KEY_NAME

--- a/src/ecc/keystore.ts
+++ b/src/ecc/keystore.ts
@@ -37,11 +37,12 @@ export class ECCKeyStore extends KeyStoreBase implements KeyStore {
     charSize: CharSize = 16
   ): Promise<string> {
     const pubkey = await keys.importPublicKey(publicKey, this.cfg.curve, KeyUse.Read)
+    const opts  = { alg: this.cfg.symmAlg, length: this.cfg.symmLen }
     const cipherText = await operations.encryptBytes(
       utils.strToArrBuf(msg, charSize),
       this.readKey.privateKey,
       pubkey,
-      this.cfg.symmAlg
+      opts
     )
     return utils.arrBufToBase64(cipherText)
   }
@@ -52,11 +53,12 @@ export class ECCKeyStore extends KeyStoreBase implements KeyStore {
     charSize: CharSize = 16
   ): Promise<string> {
     const pubkey = await keys.importPublicKey(publicKey, this.cfg.curve, KeyUse.Read)
+    const opts  = { alg: this.cfg.symmAlg, length: this.cfg.symmLen }
     const msgBytes = await operations.decryptBytes(
       utils.base64ToArrBuf(cipherText),
       this.readKey.privateKey,
       pubkey,
-      this.cfg.symmAlg
+      opts
     )
     return utils.arrBufToStr(msgBytes, charSize)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type Config = {
   curve: EccCurve
   rsaSize: RsaSize
   symmAlg: SymmAlg
+  symmLen: SymmKeyLength
   hashAlg: HashAlg
   readKeyName: string
   writeKeyName: string

--- a/test/ecc.keystore.test.ts
+++ b/test/ecc.keystore.test.ts
@@ -110,7 +110,10 @@ describe("ECCKeyStore", () => {
           mock.msgBytes,
           mock.keys.privateKey,
           mock.encryptForKey.publicKey,
-          config.defaultConfig.symmAlg
+          {
+            alg: config.defaultConfig.symmAlg,
+            length: config.defaultConfig.symmLen
+          }
         ]
       },
       {
@@ -141,7 +144,10 @@ describe("ECCKeyStore", () => {
           mock.cipherBytes,
           mock.keys.privateKey,
           mock.encryptForKey.publicKey,
-          config.defaultConfig.symmAlg
+          {
+            alg: config.defaultConfig.symmAlg,
+            length: config.defaultConfig.symmLen
+          }
         ]
       },
       {


### PR DESCRIPTION
## Problem
- Not properly passing symm length param for encrypt/decrypt in ecc.keystore

## Solution
- add symmLen to cfg
- properly pass it to encrypt/decrypt
- add to README