### PR TITLE
Package with CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystore-idb",
-  "version": "0.10.0-alpha",
+  "version": "0.10.0",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "keystore-idb",
-  "version": "0.9.0",
+  "version": "0.10.0-alpha",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
-  "main": "index.umd.js",
+  "main": "index.cjs.js",
   "module": "index.es5.js",
+  "browser": "index.umd.js",
   "typings": "types/index.d.ts",
   "author": "Daniel Holmgren <daniel@fission.codes>",
   "repository": {
@@ -36,6 +37,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/keystore-idb/**/*"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -90,10 +94,11 @@
     "replace-in-file": "^5.0.2",
     "rimraf": "^3.0.2",
     "rollup": "^1.31.1",
+    "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-json": "^4.0.0",
+    "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-sourcemaps": "^0.5.0",
     "rollup-plugin-typescript2": "^0.26.0",
     "sinon": "^9.0.0",
     "travis-deploy-once": "^5.0.11",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
-    "transformIgnorePatterns": [
-      "node_modules/keystore-idb/**/*"
-    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,35 +1,87 @@
+import babel from 'rollup-plugin-babel'
 import resolve from 'rollup-plugin-node-resolve'
 import commonjs from 'rollup-plugin-commonjs'
-import sourceMaps from 'rollup-plugin-sourcemaps'
-import typescript from 'rollup-plugin-typescript2'
 import json from 'rollup-plugin-json'
+import polyfills from 'rollup-plugin-node-polyfills'
+import typescript from 'rollup-plugin-typescript2'
 
+// Require understands JSON files.
 const pkg = require('./package.json')
 
-export default {
-  input: `src/index.ts`,
-  output: [
-    { file: `dist/${pkg.main}`, name: 'index', format: 'umd', sourcemap: true },
-    { file: `dist/${pkg.module}`, format: 'es', sourcemap: true },
-  ],
-  // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
-  external: [],
-  watch: {
-    include: 'src/**',
-  },
-  plugins: [
-    // Allow json resolution
-    json(),
-    // Compile TypeScript files
-    typescript({ useTsconfigDeclarationDir: true }),
-    // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
-    commonjs(),
-    // Allow node_modules resolution, so you can use 'external' to control
-    // which external modules to include in the bundle
-    // https://github.com/rollup/rollup-plugin-node-resolve#usage
-    resolve(),
+const input = 'src/index.ts'
+const name = 'keystore'
 
-    // Resolve source maps to the original source
-    sourceMaps(),
-  ],
+// For importing modules with `this` at the top level:
+// https://github.com/WebReflection/hyperHTML/issues/304#issuecomment-443950244
+const context = 'null'
+
+// External dependencies tell Rollup "it's ok that you can't resolve these modules;
+// don't try to bundle them but rather leave their import statements in place"
+const external = []
+
+const plugins = [
+  // Allow json resolution
+  json(),
+
+  // Compile TypeScript files
+  // We use CommonJS for lib but ESNext as compiler step for Rollup, hence the override
+  typescript({ 
+    useTsconfigDeclarationDir: true,
+    tsconfigOverride: { 
+      compilerOptions: { module: "ESNext"} 
+    }
+  }),
+
+  // Node modules resolution
+  resolve({ browser: true, preferBuiltins: true }),
+
+  // // Let's transpile our own ES6 code into ES5
+  babel({ exclude: 'node_modules/**' }),
+
+  // Most packages in node_modules are legacy CommonJS, so let's convert them to ES
+  commonjs(),
+
+  // Polyfills for node builtins/globals
+  polyfills(),
+]
+
+// browser-friendly UMD build
+const configUMD = {
+  input,
+  output: {
+    name,
+    file: `dist/${pkg.browser}`,
+    format: 'umd',
+    sourcemap: true
+  },
+  plugins,
+  external,
+  context
 }
+
+// CommonJS (for Node) and ES module (for bundlers) build.
+// (We could have three entries in the configuration array
+// instead of two, but it's quicker to generate multiple
+// builds from a single configuration where possible, using
+// an array for the `output` option, where we can specify
+// `file` and `format` for each target)
+const configCjsAndEs = {
+  input,
+  output: [
+    {
+      file: `dist/${pkg.main}`,
+      format: 'cjs',
+      sourcemap: true
+    },
+    {
+      file: `dist/${pkg.module}`,
+      format: 'es',
+      sourcemap: true
+    }
+  ],
+  plugins,
+  external,
+  context
+}
+
+export default [configUMD, configCjsAndEs]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es5",
-    "module":"es6",
+    "module":"CommonJS",
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "strict": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,7 +132,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
   integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
@@ -952,13 +952,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
-
-"@rollup/pluginutils@^3.0.1":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.0.8.tgz#4e94d128d94b90699e517ef045422960d18c8fde"
-  integrity sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==
-  dependencies:
-    estree-walker "^1.0.1"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -2275,11 +2268,6 @@ estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
-
-estree-walker@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
-  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -3941,7 +3929,7 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-magic-string@^0.25.2:
+magic-string@^0.25.2, magic-string@^0.25.3:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -4916,6 +4904,14 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-babel@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz#d15bd259466a9d1accbdb2fe2fff17c52d030acb"
+  integrity sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    rollup-pluginutils "^2.8.1"
+
 rollup-plugin-commonjs@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz#417af3b54503878e084d127adf4d1caf8beb86fb"
@@ -4927,12 +4923,28 @@ rollup-plugin-commonjs@^10.1.0:
     resolve "^1.11.0"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-inject@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz#e4233855bfba6c0c12a312fd6649dff9a13ee9f4"
+  integrity sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==
+  dependencies:
+    estree-walker "^0.6.1"
+    magic-string "^0.25.3"
+    rollup-pluginutils "^2.8.1"
+
 rollup-plugin-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-4.0.0.tgz#a18da0a4b30bf5ca1ee76ddb1422afbb84ae2b9e"
   integrity sha512-hgb8N7Cgfw5SZAkb3jf0QXii6QX/FOkiIq2M7BAQIEydjHvTyxXHQiIzZaTFgx1GK0cRCHOCBHIyEkkLdWKxow==
   dependencies:
     rollup-pluginutils "^2.5.0"
+
+rollup-plugin-node-polyfills@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz#53092a2744837164d5b8a28812ba5f3ff61109fd"
+  integrity sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==
+  dependencies:
+    rollup-plugin-inject "^3.0.0"
 
 rollup-plugin-node-resolve@^5.2.0:
   version "5.2.0"
@@ -4944,14 +4956,6 @@ rollup-plugin-node-resolve@^5.2.0:
     is-module "^1.0.0"
     resolve "^1.11.1"
     rollup-pluginutils "^2.8.1"
-
-rollup-plugin-sourcemaps@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.5.0.tgz#898e8411c9b5b7b524b4d96c3b41d5c43f9da77e"
-  integrity sha512-xp2vvRvgnYiXydgf/JFFFgYxrqMaQaOrK/g6yZvgwT9R1TSYjD3HKku1pD7iQNjQHkl5yGpokvJLp7cP/lR+aQ==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.1"
-    source-map-resolve "^0.5.3"
 
 rollup-plugin-typescript2@^0.26.0:
   version "0.26.0"
@@ -5186,7 +5190,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.3:
+source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==


### PR DESCRIPTION
## Problem
Rollup outputs CommonJS/UMD/ES5, but Typescript outputs ES6. This causes issues in some cases when importing submodules (ie `import aes from 'keystore-idb/aes`). For instance, Jest freaks out and fails when some module is ES6.

## Solution
Change tsconfig to `CommonJS`. Override this in Rollup config to compile to `ESNext` before doing the rest of the rollup

Also updated rollup config to what we've been using in ts-sdk for better compatibility. It hasn't been causing any issues with this, but this should future proof it better. 

(published as `keystore-idb@0.10.0-alpha` & it seems to work well :+1:)