### PR TITLE
Cfg overwrites for keystore methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystore-idb",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,13 @@ export async function eccEnabled(): Promise<boolean> {
   return true
 }
 
+export function merge(cfg: Config, overwrites: Partial<Config> = {}): Config {
+  return {
+    ...cfg,
+    ...overwrites
+  }
+}
+
 export function symmKeyOpts(cfg: Config): Partial<SymmKeyOpts> {
   return { alg: cfg.symmAlg, length: cfg.symmLen }
 }
@@ -64,5 +71,6 @@ export default {
   defaultConfig,
   normalize,
   eccEnabled,
+  merge,
   symmKeyOpts
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import config from '../src/config'
-import { CryptoSystem } from '../src/types'
+import { CryptoSystem, SymmAlg, SymmKeyLength } from '../src/types'
 import utils from '../src/utils'
 import { mock } from './utils'
 
@@ -107,4 +107,21 @@ describe('config', () => {
       expect(cfg).toEqual(modifiedDef)
     })
   })
+
+  describe('merge', () => {
+    it('it correctly merges configs', () => {
+      const merged = config.merge(config.defaultConfig, { symmAlg: SymmAlg.AES_CBC, symmLen: SymmKeyLength.B192 })
+      expect(merged).toEqual({
+        ...config.defaultConfig,
+        symmAlg: SymmAlg.AES_CBC,
+        symmLen: SymmKeyLength.B192
+      })
+    })
+
+    it('it works when an empty overwrite is passed', () => {
+      const merged = config.merge(config.defaultConfig)
+      expect(merged).toEqual(config.defaultConfig)
+    })
+  })
+
 })


### PR DESCRIPTION
## Problem
A Keystore is instantiated with certain config options, but sometimes you want to do operations with a different cfg. Ie you might have a keystore that defaults to 16-bit char encoding, but then need to sign an UTF-8 string.

## Solution
Add an optional cfg param on each KS method for overwriting the keystore's cfg