### PR TITLE
String operations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,4 +9,7 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
   ],
+  rules: {
+    '@typescript-eslint/no-use-before-define': ['error', 'nofunc']
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystore-idb",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/aes/keys.ts
+++ b/src/aes/keys.ts
@@ -29,5 +29,5 @@ export async function importKey(base64key: string, opts?: Partial<SymmKeyOpts>):
 
 export default {
   makeKey,
-  importKey
+  importKey,
 }

--- a/src/aes/operations.ts
+++ b/src/aes/operations.ts
@@ -8,7 +8,7 @@ export async function encryptBytes(
   key: SymmKey | string,
   opts?: Partial<SymmKeyOpts>
 ): Promise<CipherText> {
-  const data = utils.normalizeTextToBuf(msg)
+  const data = utils.normalizeUtf16ToBuf(msg)
   const importedKey = typeof key === 'string' ? await keys.importKey(key, opts) : key
   const alg = opts?.alg || DEFAULT_SYMM_ALG
   const iv = opts?.iv || utils.randomBuf(16)
@@ -31,7 +31,7 @@ export async function decryptBytes(
   key: SymmKey | string,
   opts?: Partial<SymmKeyOpts>
 ): Promise<ArrayBuffer> {
-  const cipherText = utils.normalizeCipherToBuf(msg)
+  const cipherText = utils.normalizeBase64ToBuf(msg)
   const importedKey = typeof key === 'string' ? await keys.importKey(key, opts) : key
   const alg = opts?.alg || DEFAULT_SYMM_ALG
   const iv = cipherText.slice(0, 16)

--- a/src/aes/operations.ts
+++ b/src/aes/operations.ts
@@ -1,9 +1,15 @@
 import keys from './keys'
 import utils from '../utils'
 import { DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
-import { SymmKey, SymmKeyOpts, SymmAlg, CipherText } from '../types'
+import { SymmKey, SymmKeyOpts, SymmAlg, CipherText, Msg } from '../types'
 
-export async function encryptBytes(data: ArrayBuffer, key: SymmKey, opts?: Partial<SymmKeyOpts>): Promise<CipherText> {
+export async function encryptBytes(
+  msg: Msg,
+  key: SymmKey | string,
+  opts?: Partial<SymmKeyOpts>
+): Promise<CipherText> {
+  const data = utils.normalizeToBuf(msg)
+  const importedKey = typeof key === 'string' ? await keys.importKey(key, opts) : key
   const alg = opts?.alg || DEFAULT_SYMM_ALG
   const iv = opts?.iv || utils.randomBuf(16)
   const cipherBuf = await window.crypto.subtle.encrypt(
@@ -14,13 +20,19 @@ export async function encryptBytes(data: ArrayBuffer, key: SymmKey, opts?: Parti
       iv: alg === SymmAlg.AES_CTR ? undefined : iv,
       counter: alg === SymmAlg.AES_CTR ? new Uint8Array(iv) : undefined,
     },
-    key,
+    importedKey,
     data
   )
   return utils.joinBufs(iv, cipherBuf)
 }
 
-export async function decryptBytes(cipherText: CipherText, key: SymmKey, opts?: Partial<SymmKeyOpts>): Promise<ArrayBuffer> {
+export async function decryptBytes(
+  msg: Msg,
+  key: SymmKey | string,
+  opts?: Partial<SymmKeyOpts>
+): Promise<ArrayBuffer> {
+  const cipherText = utils.normalizeToBuf(msg)
+  const importedKey = typeof key === 'string' ? await keys.importKey(key, opts) : key
   const alg = opts?.alg || DEFAULT_SYMM_ALG
   const iv = cipherText.slice(0, 16)
   const cipherBytes = cipherText.slice(16)
@@ -31,25 +43,30 @@ export async function decryptBytes(cipherText: CipherText, key: SymmKey, opts?: 
       iv: alg === SymmAlg.AES_CTR ? undefined : iv,
       counter: alg === SymmAlg.AES_CTR ? new Uint8Array(iv) : undefined,
     },
-    key,
+    importedKey,
     cipherBytes
   )
   return msgBuff
 }
 
-export async function encrypt(msg: string, key: string, opts?: Partial<SymmKeyOpts>): Promise<string> {
-  const buf = utils.strToArrBuf(msg, 16)
-  const cipherKey = await keys.importKey(key, opts)
-  const cipherText = await encryptBytes(buf, cipherKey, opts)
+export async function encrypt(
+  msg: Msg,
+  key: SymmKey | string,
+  opts?: Partial<SymmKeyOpts>
+): Promise<string> {
+  const cipherText = await encryptBytes(msg, key, opts)
   return utils.arrBufToBase64(cipherText)
 }
 
-export async function decrypt(cipherText: string, key: string, opts?: Partial<SymmKeyOpts>): Promise<string> {
-  const buf = utils.base64ToArrBuf(cipherText)
-  const cipherKey = await keys.importKey(key, opts)
-  const msgBytes = await decryptBytes(buf, cipherKey, opts)
+export async function decrypt(
+  msg: Msg,
+  key: SymmKey | string,
+  opts?: Partial<SymmKeyOpts>
+): Promise<string> {
+  const msgBytes = await decryptBytes(msg, key, opts)
   return utils.arrBufToStr(msgBytes, 16)
 }
+
 
 export async function exportKey(key: SymmKey): Promise<string> {
   const raw = await window.crypto.subtle.exportKey('raw', key)

--- a/src/aes/operations.ts
+++ b/src/aes/operations.ts
@@ -8,7 +8,7 @@ export async function encryptBytes(
   key: SymmKey | string,
   opts?: Partial<SymmKeyOpts>
 ): Promise<CipherText> {
-  const data = utils.normalizeToBuf(msg)
+  const data = utils.normalizeTextToBuf(msg)
   const importedKey = typeof key === 'string' ? await keys.importKey(key, opts) : key
   const alg = opts?.alg || DEFAULT_SYMM_ALG
   const iv = opts?.iv || utils.randomBuf(16)
@@ -31,7 +31,7 @@ export async function decryptBytes(
   key: SymmKey | string,
   opts?: Partial<SymmKeyOpts>
 ): Promise<ArrayBuffer> {
-  const cipherText = utils.normalizeToBuf(msg)
+  const cipherText = utils.normalizeCipherToBuf(msg)
   const importedKey = typeof key === 'string' ? await keys.importKey(key, opts) : key
   const alg = opts?.alg || DEFAULT_SYMM_ALG
   const iv = cipherText.slice(0, 16)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import ecc from './ecc/keys'
 import {
   DEFAULT_CRYPTOSYSTEM,
-  DEFAULT_EccCurve,
+  DEFAULT_ECC_CURVE,
   DEFAULT_RsaSize,
   DEFAULT_SYMM_ALG,
   DEFAULT_SYMM_LEN,
@@ -16,7 +16,7 @@ import utils from './utils'
 
 export const defaultConfig = {
   type: DEFAULT_CRYPTOSYSTEM,
-  curve: DEFAULT_EccCurve,
+  curve: DEFAULT_ECC_CURVE,
   rsaSize: DEFAULT_RsaSize,
   symmAlg: DEFAULT_SYMM_ALG,
   symmLen: DEFAULT_SYMM_LEN,
@@ -49,7 +49,7 @@ export function normalize(
 // Attempt a structural clone of an ECC Key (required to store in IndexedDB)
 // If it throws an error, use RSA, otherwise use ECC
 export async function eccEnabled(): Promise<boolean> {
-  const keypair = await ecc.makeKeypair(DEFAULT_EccCurve, KeyUse.Read)
+  const keypair = await ecc.makeKeypair(DEFAULT_ECC_CURVE, KeyUse.Read)
   try {
     await utils.structuralClone(keypair)
   } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import ecc from './ecc/keys'
 import {
   DEFAULT_CRYPTOSYSTEM,
   DEFAULT_ECC_CURVE,
-  DEFAULT_RsaSize,
+  DEFAULT_RSA_SIZE,
   DEFAULT_SYMM_ALG,
   DEFAULT_SYMM_LEN,
   DEFAULT_HASH_ALG,
@@ -17,7 +17,7 @@ import utils from './utils'
 export const defaultConfig = {
   type: DEFAULT_CRYPTOSYSTEM,
   curve: DEFAULT_ECC_CURVE,
-  rsaSize: DEFAULT_RsaSize,
+  rsaSize: DEFAULT_RSA_SIZE,
   symmAlg: DEFAULT_SYMM_ALG,
   symmLen: DEFAULT_SYMM_LEN,
   hashAlg: DEFAULT_HASH_ALG,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export const RSA_WRITE_ALG = 'RSASSA-PKCS1-v1_5'
 export const SALT_LENGTH = 128
 
 export const DEFAULT_CRYPTOSYSTEM = 'ecc'
-export const DEFAULT_EccCurve = EccCurve.P_256
+export const DEFAULT_ECC_CURVE = EccCurve.P_256
 export const DEFAULT_RsaSize = RsaSize.B2048
 export const DEFAULT_SYMM_ALG = SymmAlg.AES_CTR
 export const DEFAULT_SYMM_LEN = SymmKeyLength.B128
@@ -25,7 +25,7 @@ export default {
   RSA_WRITE_ALG,
   SALT_LENGTH,
   DEFAULT_CRYPTOSYSTEM,
-  DEFAULT_EccCurve,
+  DEFAULT_ECC_CURVE,
   DEFAULT_RsaSize,
   DEFAULT_SYMM_ALG,
   DEFAULT_HASH_ALG,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ export const SALT_LENGTH = 128
 
 export const DEFAULT_CRYPTOSYSTEM = 'ecc'
 export const DEFAULT_ECC_CURVE = EccCurve.P_256
-export const DEFAULT_RsaSize = RsaSize.B2048
+export const DEFAULT_RSA_SIZE = RsaSize.B2048
 export const DEFAULT_SYMM_ALG = SymmAlg.AES_CTR
 export const DEFAULT_SYMM_LEN = SymmKeyLength.B128
 export const DEFAULT_HASH_ALG = HashAlg.SHA_256
@@ -26,7 +26,7 @@ export default {
   SALT_LENGTH,
   DEFAULT_CRYPTOSYSTEM,
   DEFAULT_ECC_CURVE,
-  DEFAULT_RsaSize,
+  DEFAULT_RSA_SIZE,
   DEFAULT_SYMM_ALG,
   DEFAULT_HASH_ALG,
   DEFAULT_CHAR_SIZE,

--- a/src/ecc/keystore.ts
+++ b/src/ecc/keystore.ts
@@ -28,15 +28,13 @@ export class ECCKeyStore extends KeyStoreBase implements KeyStore {
 
 
   async sign(msg: string, cfg?: Partial<Config>): Promise<string> {
-    const mergedCfg = config.merge(this.cfg, cfg)
     const writeKey = await this.writeKey()
 
-    const sigBytes = await operations.signBytes(
-      utils.strToArrBuf(msg, mergedCfg.charSize),
+    return await operations.signString(
+      msg,
       writeKey.privateKey,
-      mergedCfg.hashAlg
+      config.merge(this.cfg, cfg)
     )
-    return utils.arrBufToBase64(sigBytes)
   }
 
   async verify(
@@ -45,14 +43,11 @@ export class ECCKeyStore extends KeyStoreBase implements KeyStore {
     publicKey: string,
     cfg?: Partial<Config>
   ): Promise<boolean> {
-    const mergedCfg = config.merge(this.cfg, cfg)
-    const pubkey = await keys.importPublicKey(publicKey, mergedCfg.curve, KeyUse.Write)
-
-    return operations.verifyBytes(
-      utils.strToArrBuf(msg, mergedCfg.charSize),
-      utils.base64ToArrBuf(sig),
-      pubkey,
-      mergedCfg.hashAlg
+    return operations.verifyString (
+      msg,
+      sig,
+      publicKey,
+      config.merge(this.cfg, cfg)
     )
   }
 
@@ -61,17 +56,14 @@ export class ECCKeyStore extends KeyStoreBase implements KeyStore {
     publicKey: string,
     cfg?: Partial<Config>
   ): Promise<string> {
-    const mergedCfg = config.merge(this.cfg, cfg)
     const readKey = await this.readKey()
-    const pubkey = await keys.importPublicKey(publicKey, mergedCfg.curve, KeyUse.Read)
 
-    const cipherText = await operations.encryptBytes(
-      utils.strToArrBuf(msg, mergedCfg.charSize),
+    return operations.encryptString(
+      msg,
       readKey.privateKey,
-      pubkey,
-      config.symmKeyOpts(mergedCfg)
+      publicKey,
+      config.merge(this.cfg, cfg)
     )
-    return utils.arrBufToBase64(cipherText)
   }
 
   async decrypt(
@@ -79,17 +71,14 @@ export class ECCKeyStore extends KeyStoreBase implements KeyStore {
     publicKey: string,
     cfg?: Partial<Config>
   ): Promise<string> {
-    const mergedCfg = config.merge(this.cfg, cfg)
     const readKey = await this.readKey()
-    const pubkey = await keys.importPublicKey(publicKey, mergedCfg.curve, KeyUse.Read)
 
-    const msgBytes = await operations.decryptBytes(
-      utils.base64ToArrBuf(cipherText),
+    return operations.decryptString(
+      cipherText,
       readKey.privateKey,
-      pubkey,
-      config.symmKeyOpts(mergedCfg)
+      publicKey,
+      config.merge(this.cfg, cfg)
     )
-    return utils.arrBufToStr(msgBytes, mergedCfg.charSize)
   }
 
   async publicReadKey(): Promise<string> {

--- a/src/ecc/keystore.ts
+++ b/src/ecc/keystore.ts
@@ -2,7 +2,6 @@ import IDB from '../idb'
 import keys from './keys'
 import operations from './operations'
 import config from '../config'
-import utils from '../utils'
 import KeyStoreBase from '../keystore/base'
 import { KeyStore, Config, KeyUse, CryptoSystem } from '../types'
 

--- a/src/ecc/operations.ts
+++ b/src/ecc/operations.ts
@@ -2,8 +2,7 @@ import aes from '../aes'
 import keys from './keys'
 import utils, { normalizeBase64ToBuf, normalizeUnicodeToBuf } from '../utils'
 import { DEFAULT_CHAR_SIZE, DEFAULT_ECC_CURVE, DEFAULT_HASH_ALG, ECC_READ_ALG, ECC_WRITE_ALG, DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
-import { CharSize, Config, EccCurve, Msg, PrivateKey, PublicKey, HashAlg, KeyUse, SymmKey, SymmKeyOpts, CipherText } from '../types'
-import config, { defaultConfig } from '../config'
+import { CharSize, EccCurve, Msg, PrivateKey, PublicKey, HashAlg, KeyUse, SymmKey, SymmKeyOpts } from '../types'
 
 
 export async function sign(

--- a/src/ecc/operations.ts
+++ b/src/ecc/operations.ts
@@ -1,30 +1,130 @@
 import aes from '../aes'
+import keys from './keys'
 import utils from '../utils'
 import { ECC_READ_ALG, ECC_WRITE_ALG, DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
-import { PrivateKey, PublicKey, HashAlg, SymmKey, SymmKeyOpts, CipherText } from '../types'
+import { Config, PrivateKey, PublicKey, HashAlg, KeyUse, SymmKey, SymmKeyOpts, CipherText } from '../types'
+import config, { defaultConfig } from '../config'
 
-export async function signBytes(data: ArrayBuffer, privKey: PrivateKey, hashAlg: HashAlg): Promise<ArrayBuffer> {
+export async function signBytes(
+  data: ArrayBuffer,
+  privateKey: PrivateKey,
+  hashAlg: HashAlg
+): Promise<ArrayBuffer> {
   return window.crypto.subtle.sign(
     { name: ECC_WRITE_ALG, hash: {name: hashAlg }},
-    privKey,
+    privateKey,
     data
   )
 }
 
-export async function verifyBytes(data: ArrayBuffer, sig: ArrayBuffer, publicKey: PublicKey, hashAlg: HashAlg): Promise<boolean> {
+export async function signString(
+  msg: string,
+  privateKey: PrivateKey,
+  cfg: Config = defaultConfig
+) {
+  const sigBytes = await signBytes(
+    utils.strToArrBuf(msg, cfg.charSize),
+    privateKey,
+    cfg.hashAlg
+  )
+
+  return utils.arrBufToBase64(sigBytes)
+}
+
+export async function verifyBytes(
+  data: ArrayBuffer,
+  sig: ArrayBuffer,
+  publicKey: PublicKey,
+  hashAlg: HashAlg
+): Promise<boolean> {
   return window.crypto.subtle.verify(
     { name: ECC_WRITE_ALG, hash: {name: hashAlg }},
     publicKey,
-    sig, 
-    data 
+    sig,
+    data
   )
+}
+
+export async function verifyString(
+  msg: string,
+  sig: string,
+  publicKey64: string,
+  cfg: Config = defaultConfig
+) {
+  const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Write)
+
+  return verifyBytes(
+    utils.strToArrBuf(msg, cfg.charSize),
+    utils.base64ToArrBuf(sig),
+    publicKey,
+    cfg.hashAlg
+  )
+}
+
+export async function encryptBytes(
+  data: ArrayBuffer,
+  privateKey: PrivateKey,
+  publicKey: PublicKey,
+  opts?: Partial<SymmKeyOpts>
+): Promise<CipherText> {
+  const cipherKey = await getSharedKey(privateKey, publicKey, opts)
+  return aes.encryptBytes(data, cipherKey, opts)
+}
+
+export async function encryptString(
+  msg: string,
+  privateKey: PrivateKey,
+  publicKey64: string,
+  cfg: Config = defaultConfig
+) {
+  const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Read)
+  const cipherText = await encryptBytes(
+    utils.strToArrBuf(msg, cfg.charSize),
+    privateKey,
+    publicKey,
+    config.symmKeyOpts(cfg)
+  )
+
+  return utils.arrBufToBase64(cipherText)
+}
+
+export async function decryptBytes(
+  cipherText: CipherText,
+  privateKey: PrivateKey,
+  publicKey: PublicKey,
+  opts?: Partial<SymmKeyOpts>
+): Promise<ArrayBuffer> {
+  const cipherKey = await getSharedKey(privateKey, publicKey, opts)
+  return aes.decryptBytes(cipherText, cipherKey, opts)
+}
+
+export async function decryptString(
+  cipherText: string,
+  privateKey: PrivateKey,
+  publicKey64: string,
+  cfg: Config = defaultConfig
+) {
+  const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Read)
+  const msgBytes = await decryptBytes(
+    utils.base64ToArrBuf(cipherText),
+    privateKey,
+    publicKey,
+    config.symmKeyOpts(cfg)
+  )
+
+  return utils.arrBufToStr(msgBytes, cfg.charSize)
+}
+
+export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {
+  const raw = await window.crypto.subtle.exportKey('raw', keypair.publicKey)
+  return utils.arrBufToBase64(raw)
 }
 
 export async function getSharedKey(privateKey: PrivateKey, publicKey: PublicKey, opts?: Partial<SymmKeyOpts>): Promise<SymmKey> {
   return window.crypto.subtle.deriveKey(
     { name: ECC_READ_ALG, public: publicKey },
     privateKey,
-    { 
+    {
       name: opts?.alg || DEFAULT_SYMM_ALG,
       length: opts?.length || DEFAULT_SYMM_LEN
     },
@@ -33,26 +133,15 @@ export async function getSharedKey(privateKey: PrivateKey, publicKey: PublicKey,
   )
 }
 
-export async function encryptBytes(data: ArrayBuffer, privateKey: PrivateKey, publicKey: PublicKey, opts?: Partial<SymmKeyOpts>): Promise<CipherText> {
-  const cipherKey = await getSharedKey(privateKey, publicKey, opts)
-  return aes.encryptBytes(data, cipherKey, opts)
-}
-
-export async function decryptBytes(cipherText: CipherText, privateKey: PrivateKey, publicKey: PublicKey, opts?: Partial<SymmKeyOpts>): Promise<ArrayBuffer> {
-  const cipherKey = await getSharedKey(privateKey, publicKey, opts)
-  return aes.decryptBytes(cipherText, cipherKey, opts)
-}
-
-export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {
-  const raw = await window.crypto.subtle.exportKey('raw', keypair.publicKey)
-  return utils.arrBufToBase64(raw)
-}
-
 export default {
   signBytes,
+  signString,
   verifyBytes,
-  getSharedKey,
+  verifyString,
   encryptBytes,
+  encryptString,
   decryptBytes,
-  getPublicKey
+  decryptString,
+  getPublicKey,
+  getSharedKey
 }

--- a/src/ecc/operations.ts
+++ b/src/ecc/operations.ts
@@ -1,118 +1,72 @@
 import aes from '../aes'
 import keys from './keys'
-import utils from '../utils'
-import { ECC_READ_ALG, ECC_WRITE_ALG, DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
-import { Config, PrivateKey, PublicKey, HashAlg, KeyUse, SymmKey, SymmKeyOpts, CipherText } from '../types'
+import utils, { normalizeBase64ToBuf, normalizeUnicodeToBuf } from '../utils'
+import { DEFAULT_CHAR_SIZE, DEFAULT_EccCurve, DEFAULT_HASH_ALG, ECC_READ_ALG, ECC_WRITE_ALG, DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
+import { CharSize, Config, EccCurve, Msg, PrivateKey, PublicKey, HashAlg, KeyUse, SymmKey, SymmKeyOpts, CipherText } from '../types'
 import config, { defaultConfig } from '../config'
 
-export async function signBytes(
-  data: ArrayBuffer,
+
+export async function sign(
+  msg: Msg,
   privateKey: PrivateKey,
-  hashAlg: HashAlg
+  charSize: CharSize = DEFAULT_CHAR_SIZE,
+  hashAlg: HashAlg = DEFAULT_HASH_ALG,
 ): Promise<ArrayBuffer> {
   return window.crypto.subtle.sign(
-    { name: ECC_WRITE_ALG, hash: {name: hashAlg }},
+    { name: ECC_WRITE_ALG, hash: { name: hashAlg }},
     privateKey,
-    data
+    normalizeUnicodeToBuf(msg, charSize)
   )
 }
 
-export async function signString(
-  msg: string,
-  privateKey: PrivateKey,
-  cfg: Config = defaultConfig
-): Promise<string> {
-  const sigBytes = await signBytes(
-    utils.strToArrBuf(msg, cfg.charSize),
-    privateKey,
-    cfg.hashAlg
-  )
-
-  return utils.arrBufToBase64(sigBytes)
-}
-
-export async function verifyBytes(
-  data: ArrayBuffer,
-  sig: ArrayBuffer,
-  publicKey: PublicKey,
-  hashAlg: HashAlg
+export async function verify(
+  msg: Msg,
+  sig: Msg,
+  publicKey: string | PublicKey,
+  charSize: CharSize = DEFAULT_CHAR_SIZE,
+  curve: EccCurve = DEFAULT_EccCurve,
+  hashAlg: HashAlg = DEFAULT_HASH_ALG
 ): Promise<boolean> {
   return window.crypto.subtle.verify(
-    { name: ECC_WRITE_ALG, hash: {name: hashAlg }},
-    publicKey,
-    sig,
-    data
+    { name: ECC_WRITE_ALG, hash: { name: hashAlg }},
+    typeof publicKey === "string"
+      ? await keys.importPublicKey(publicKey, curve, KeyUse.Write)
+      : publicKey,
+    normalizeBase64ToBuf(sig),
+    normalizeUnicodeToBuf(msg, charSize)
   )
 }
 
-export async function verifyString(
-  msg: string,
-  sig: string,
-  publicKey64: string,
-  cfg: Config = defaultConfig
-): Promise<boolean> {
-  const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Write)
-
-  return verifyBytes(
-    utils.strToArrBuf(msg, cfg.charSize),
-    utils.base64ToArrBuf(sig),
-    publicKey,
-    cfg.hashAlg
-  )
-}
-
-export async function encryptBytes(
-  data: ArrayBuffer,
+export async function encrypt(
+  msg: Msg,
   privateKey: PrivateKey,
-  publicKey: PublicKey,
-  opts?: Partial<SymmKeyOpts>
-): Promise<CipherText> {
-  const cipherKey = await getSharedKey(privateKey, publicKey, opts)
-  return aes.encryptBytes(data, cipherKey, opts)
-}
-
-export async function encryptString(
-  msg: string,
-  privateKey: PrivateKey,
-  publicKey64: string,
-  cfg: Config = defaultConfig
-): Promise<string> {
-  const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Read)
-  const cipherText = await encryptBytes(
-    utils.strToArrBuf(msg, cfg.charSize),
-    privateKey,
-    publicKey,
-    config.symmKeyOpts(cfg)
-  )
-
-  return utils.arrBufToBase64(cipherText)
-}
-
-export async function decryptBytes(
-  cipherText: CipherText,
-  privateKey: PrivateKey,
-  publicKey: PublicKey,
+  publicKey: string | PublicKey,
+  charSize: CharSize = DEFAULT_CHAR_SIZE,
+  curve: EccCurve = DEFAULT_EccCurve,
   opts?: Partial<SymmKeyOpts>
 ): Promise<ArrayBuffer> {
-  const cipherKey = await getSharedKey(privateKey, publicKey, opts)
-  return aes.decryptBytes(cipherText, cipherKey, opts)
+  const importedPublicKey = typeof publicKey === "string"
+    ? await keys.importPublicKey(publicKey, curve, KeyUse.Read)
+    : publicKey
+
+  const cipherKey = await getSharedKey(privateKey, importedPublicKey, opts)
+  return aes.encryptBytes(normalizeUnicodeToBuf(msg, charSize), cipherKey, opts)
 }
 
-export async function decryptString(
-  cipherText: string,
+export async function decrypt(
+  msg: Msg,
   privateKey: PrivateKey,
-  publicKey64: string,
-  cfg: Config = defaultConfig
-): Promise<string> {
-  const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Read)
-  const msgBytes = await decryptBytes(
-    utils.base64ToArrBuf(cipherText),
-    privateKey,
-    publicKey,
-    config.symmKeyOpts(cfg)
-  )
+  publicKey: string | PublicKey,
+  charSize: CharSize = DEFAULT_CHAR_SIZE,
+  curve: EccCurve = DEFAULT_EccCurve,
+  opts?: Partial<SymmKeyOpts>
+): Promise<ArrayBuffer> {
+  const importedPublicKey = typeof publicKey === "string"
+    ? await keys.importPublicKey(publicKey, curve, KeyUse.Read)
+    : publicKey
 
-  return utils.arrBufToStr(msgBytes, cfg.charSize)
+  const cipherKey = await getSharedKey(privateKey, importedPublicKey, opts)
+  return aes.decryptBytes(normalizeUnicodeToBuf(msg, charSize), cipherKey, opts)
 }
 
 export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {
@@ -134,14 +88,10 @@ export async function getSharedKey(privateKey: PrivateKey, publicKey: PublicKey,
 }
 
 export default {
-  signBytes,
-  signString,
-  verifyBytes,
-  verifyString,
-  encryptBytes,
-  encryptString,
-  decryptBytes,
-  decryptString,
+  sign,
+  verify,
+  encrypt,
+  decrypt,
   getPublicKey,
   getSharedKey
 }

--- a/src/ecc/operations.ts
+++ b/src/ecc/operations.ts
@@ -21,7 +21,7 @@ export async function signString(
   msg: string,
   privateKey: PrivateKey,
   cfg: Config = defaultConfig
-) {
+): Promise<string> {
   const sigBytes = await signBytes(
     utils.strToArrBuf(msg, cfg.charSize),
     privateKey,
@@ -50,7 +50,7 @@ export async function verifyString(
   sig: string,
   publicKey64: string,
   cfg: Config = defaultConfig
-) {
+): Promise<boolean> {
   const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Write)
 
   return verifyBytes(
@@ -76,7 +76,7 @@ export async function encryptString(
   privateKey: PrivateKey,
   publicKey64: string,
   cfg: Config = defaultConfig
-) {
+): Promise<string> {
   const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Read)
   const cipherText = await encryptBytes(
     utils.strToArrBuf(msg, cfg.charSize),
@@ -103,7 +103,7 @@ export async function decryptString(
   privateKey: PrivateKey,
   publicKey64: string,
   cfg: Config = defaultConfig
-) {
+): Promise<string> {
   const publicKey = await keys.importPublicKey(publicKey64, cfg.curve, KeyUse.Read)
   const msgBytes = await decryptBytes(
     utils.base64ToArrBuf(cipherText),

--- a/src/ecc/operations.ts
+++ b/src/ecc/operations.ts
@@ -1,7 +1,7 @@
 import aes from '../aes'
 import keys from './keys'
 import utils, { normalizeBase64ToBuf, normalizeUnicodeToBuf } from '../utils'
-import { DEFAULT_CHAR_SIZE, DEFAULT_EccCurve, DEFAULT_HASH_ALG, ECC_READ_ALG, ECC_WRITE_ALG, DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
+import { DEFAULT_CHAR_SIZE, DEFAULT_ECC_CURVE, DEFAULT_HASH_ALG, ECC_READ_ALG, ECC_WRITE_ALG, DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
 import { CharSize, Config, EccCurve, Msg, PrivateKey, PublicKey, HashAlg, KeyUse, SymmKey, SymmKeyOpts, CipherText } from '../types'
 import config, { defaultConfig } from '../config'
 
@@ -24,7 +24,7 @@ export async function verify(
   sig: Msg,
   publicKey: string | PublicKey,
   charSize: CharSize = DEFAULT_CHAR_SIZE,
-  curve: EccCurve = DEFAULT_EccCurve,
+  curve: EccCurve = DEFAULT_ECC_CURVE,
   hashAlg: HashAlg = DEFAULT_HASH_ALG
 ): Promise<boolean> {
   return window.crypto.subtle.verify(
@@ -42,7 +42,7 @@ export async function encrypt(
   privateKey: PrivateKey,
   publicKey: string | PublicKey,
   charSize: CharSize = DEFAULT_CHAR_SIZE,
-  curve: EccCurve = DEFAULT_EccCurve,
+  curve: EccCurve = DEFAULT_ECC_CURVE,
   opts?: Partial<SymmKeyOpts>
 ): Promise<ArrayBuffer> {
   const importedPublicKey = typeof publicKey === "string"
@@ -58,7 +58,7 @@ export async function decrypt(
   privateKey: PrivateKey,
   publicKey: string | PublicKey,
   charSize: CharSize = DEFAULT_CHAR_SIZE,
-  curve: EccCurve = DEFAULT_EccCurve,
+  curve: EccCurve = DEFAULT_ECC_CURVE,
   opts?: Partial<SymmKeyOpts>
 ): Promise<ArrayBuffer> {
   const importedPublicKey = typeof publicKey === "string"

--- a/src/rsa/keystore.ts
+++ b/src/rsa/keystore.ts
@@ -2,6 +2,7 @@ import IDB from '../idb'
 import keys from './keys'
 import operations from './operations'
 import config from '../config'
+import utils from '../utils'
 import KeyStoreBase from '../keystore/base'
 import { KeyStore, Config, KeyUse, CryptoSystem, Msg, PublicKey } from '../types'
 
@@ -30,13 +31,12 @@ export class RSAKeyStore extends KeyStoreBase implements KeyStore {
   async sign(msg: Msg, cfg?: Partial<Config>): Promise<string> {
     const mergedCfg = config.merge(this.cfg, cfg)
     const writeKey = await this.writeKey()
-    const signedBuf = await operations.sign(
+
+    return utils.arrBufToBase64(await operations.sign(
       msg,
       writeKey.privateKey,
       mergedCfg.charSize
-    )
-
-    return utils.arrBufToBase64(signedBuf)
+    ))
   }
 
   async verify(
@@ -62,14 +62,13 @@ export class RSAKeyStore extends KeyStoreBase implements KeyStore {
     cfg?: Partial<Config>
   ): Promise<string> {
     const mergedCfg = config.merge(this.cfg, cfg)
-    const cipherText = await operations.encrypt(
+
+    return utils.arrBufToBase64(await operations.encrypt(
       msg,
       publicKey,
       mergedCfg.charSize,
       mergedCfg.hashAlg
-    )
-
-    return utils.arrBufToBase64(cipherText)
+    ))
   }
 
   async decrypt(
@@ -78,10 +77,15 @@ export class RSAKeyStore extends KeyStoreBase implements KeyStore {
     cfg?: Partial<Config>
   ): Promise<string> {
     const readKey = await this.readKey()
+    const mergedCfg = config.merge(this.cfg, cfg)
 
-    return operations.decrypt(
-      cipherText,
-      readKey.privateKey
+    return utils.arrBufToStr(
+      await operations.decrypt(
+        cipherText,
+        readKey.privateKey,
+        mergedCfg.charSize
+      ),
+      mergedCfg.charSize
     )
   }
 

--- a/src/rsa/keystore.ts
+++ b/src/rsa/keystore.ts
@@ -30,7 +30,7 @@ export class RSAKeyStore extends KeyStoreBase implements KeyStore {
   async sign(msg: string, cfg?: Partial<Config>): Promise<string> {
     const writeKey = await this.writeKey()
 
-    return await operations.signString(
+    return operations.signString(
       msg,
       writeKey.privateKey,
       config.merge(this.cfg, cfg)
@@ -43,7 +43,7 @@ export class RSAKeyStore extends KeyStoreBase implements KeyStore {
     publicKey: string,
     cfg?: Partial<Config>
   ): Promise<boolean> {
-    return await operations.verifyString(
+    return operations.verifyString(
       msg,
       sig,
       publicKey,
@@ -56,7 +56,7 @@ export class RSAKeyStore extends KeyStoreBase implements KeyStore {
     publicKey: string,
     cfg?: Partial<Config>
   ): Promise<string> {
-    return await operations.encryptString(
+    return operations.encryptString(
       msg,
       publicKey,
       config.merge(this.cfg, cfg)
@@ -70,7 +70,7 @@ export class RSAKeyStore extends KeyStoreBase implements KeyStore {
   ): Promise<string> {
     const readKey = await this.readKey()
 
-    return await operations.decryptString(
+    return operations.decryptString(
       cipherText,
       readKey.privateKey,
       config.merge(this.cfg, cfg)

--- a/src/rsa/operations.ts
+++ b/src/rsa/operations.ts
@@ -1,7 +1,7 @@
 import keys from './keys'
-import utils, { normalizeUnicodeToBuf } from '../utils'
+import utils, { normalizeBase64ToBuf, normalizeUnicodeToBuf } from '../utils'
 import { DEFAULT_CHAR_SIZE, DEFAULT_HASH_ALG, RSA_READ_ALG, RSA_WRITE_ALG, SALT_LENGTH } from '../constants'
-import { Config, HashAlg, KeyUse, Msg, PrivateKey, PublicKey, CipherText } from '../types'
+import { CharSize, Config, HashAlg, KeyUse, Msg, PrivateKey, PublicKey, CipherText } from '../types'
 import { defaultConfig } from '../config'
 
 
@@ -39,11 +39,11 @@ export async function encrypt(
   publicKey: string | PublicKey,
   charSize: CharSize = DEFAULT_CHAR_SIZE,
   hashAlg: HashAlg = DEFAULT_HASH_ALG
-): Promise<CipherText> {
+): Promise<ArrayBuffer> {
   return window.crypto.subtle.encrypt(
     { name: RSA_READ_ALG },
     typeof publicKey === "string"
-      ? await keys.importPublicKey(publicKey, hashAlg, KeyUse.Write)
+      ? await keys.importPublicKey(publicKey, hashAlg, KeyUse.Read)
       : publicKey,
     normalizeUnicodeToBuf(msg, charSize)
   )
@@ -51,12 +51,13 @@ export async function encrypt(
 
 export async function decrypt(
   msg: Msg,
-  privateKey: PrivateKey
+  privateKey: PrivateKey,
+  charSize: CharSize = DEFAULT_CHAR_SIZE
 ): Promise<ArrayBuffer> {
   return window.crypto.subtle.decrypt(
     { name: RSA_READ_ALG },
     privateKey,
-    normalizeBase64ToBuf(msg)
+    normalizeUnicodeToBuf(msg, charSize)
   )
 }
 
@@ -66,13 +67,9 @@ export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {
 }
 
 export default {
-  signBytes,
-  signString,
-  verifyBytes,
-  verifyString,
-  encryptBytes,
-  encryptString,
-  decryptBytes,
-  decryptString,
+  sign,
+  verify,
+  encrypt,
+  decrypt,
   getPublicKey,
 }

--- a/src/rsa/operations.ts
+++ b/src/rsa/operations.ts
@@ -1,8 +1,13 @@
+import keys from './keys'
 import utils from '../utils'
 import { RSA_READ_ALG, RSA_WRITE_ALG, SALT_LENGTH } from '../constants'
-import { PrivateKey, PublicKey, CipherText } from '../types'
+import { CharSize, Config, KeyUse, PrivateKey, PublicKey, CipherText } from '../types'
+import { defaultConfig } from '../config'
 
-export async function signBytes(data: ArrayBuffer, privKey: PrivateKey): Promise<ArrayBuffer> {
+export async function signBytes(
+  data: ArrayBuffer,
+  privKey: PrivateKey
+): Promise<ArrayBuffer> {
   return window.crypto.subtle.sign(
     { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
     privKey,
@@ -10,29 +15,95 @@ export async function signBytes(data: ArrayBuffer, privKey: PrivateKey): Promise
   )
 }
 
-export async function verifyBytes(data: ArrayBuffer, sig: ArrayBuffer, publicKey: PublicKey): Promise<boolean> {
-  return window.crypto.subtle.verify(
-    { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
-    publicKey,
-    sig, 
-    data 
+export async function signString(
+  msg: string,
+  privKey: PrivateKey,
+  config: Config = defaultConfig
+): Promise<string> {
+  const sigBytes = await signBytes(
+    utils.strToArrBuf(msg, config.charSize),
+    privKey
   )
+
+  return utils.arrBufToBase64(sigBytes)
 }
 
-export async function encryptBytes(data: ArrayBuffer, publicKey: PublicKey): Promise<CipherText> {
-  return window.crypto.subtle.encrypt(
-    { name: RSA_READ_ALG },
-    publicKey,
+export async function verifyBytes(
+  data: ArrayBuffer,
+  sig: ArrayBuffer,
+  pubKey: PublicKey
+): Promise<boolean> {
+  return window.crypto.subtle.verify(
+    { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
+    pubKey,
+    sig,
     data
   )
 }
 
-export async function decryptBytes(cipherText: CipherText, privateKey: PrivateKey): Promise<ArrayBuffer> {
+export async function verifyString(
+  msg: string,
+  signature: string,
+  publicKey: string,
+  config: Config = defaultConfig
+): Promise<boolean> {
+  const pubKey = await keys.importPublicKey(publicKey, config.hashAlg, KeyUse.Write)
+
+  return verifyBytes(
+    utils.strToArrBuf(msg, config.charSize),
+    utils.base64ToArrBuf(signature),
+    pubKey
+  )
+}
+
+export async function encryptBytes(
+  data: ArrayBuffer,
+  pubKey: PublicKey
+): Promise<CipherText> {
+  return window.crypto.subtle.encrypt(
+    { name: RSA_READ_ALG },
+    pubKey,
+    data
+  )
+}
+
+export async function encryptString(
+  msg: string,
+  publicKey: string,
+  config: Config = defaultConfig
+): Promise<string> {
+  const pubKey = await keys.importPublicKey(publicKey, config.hashAlg, KeyUse.Read)
+
+  const cipherText = await encryptBytes(
+    utils.strToArrBuf(msg, config.charSize),
+    pubKey
+  )
+
+  return utils.arrBufToBase64(cipherText)
+}
+
+export async function decryptBytes(
+  cipherText: CipherText,
+  privateKey: PrivateKey
+): Promise<ArrayBuffer> {
   return window.crypto.subtle.decrypt(
     { name: RSA_READ_ALG },
     privateKey,
     cipherText
   )
+}
+
+export async function decryptString(
+  cipherText: string,
+  privateKey: PrivateKey,
+  config: Config = defaultConfig
+): Promise<string> {
+  const msgBytes = await decryptBytes(
+    utils.base64ToArrBuf(cipherText),
+    privateKey
+  )
+
+  return utils.arrBufToStr(msgBytes, config.charSize)
 }
 
 export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {
@@ -42,8 +113,12 @@ export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {
 
 export default {
   signBytes,
+  signString,
   verifyBytes,
+  verifyString,
   encryptBytes,
+  encryptString,
   decryptBytes,
+  decryptString,
   getPublicKey,
 }

--- a/src/rsa/operations.ts
+++ b/src/rsa/operations.ts
@@ -1,7 +1,7 @@
 import keys from './keys'
 import utils from '../utils'
 import { RSA_READ_ALG, RSA_WRITE_ALG, SALT_LENGTH } from '../constants'
-import { CharSize, Config, KeyUse, PrivateKey, PublicKey, CipherText } from '../types'
+import { Config, KeyUse, PrivateKey, PublicKey, CipherText } from '../types'
 import { defaultConfig } from '../config'
 
 export async function signBytes(

--- a/src/rsa/operations.ts
+++ b/src/rsa/operations.ts
@@ -1,108 +1,63 @@
 import keys from './keys'
-import utils from '../utils'
-import { RSA_READ_ALG, RSA_WRITE_ALG, SALT_LENGTH } from '../constants'
-import { Config, KeyUse, PrivateKey, PublicKey, CipherText } from '../types'
+import utils, { normalizeUnicodeToBuf } from '../utils'
+import { DEFAULT_CHAR_SIZE, DEFAULT_HASH_ALG, RSA_READ_ALG, RSA_WRITE_ALG, SALT_LENGTH } from '../constants'
+import { Config, HashAlg, KeyUse, Msg, PrivateKey, PublicKey, CipherText } from '../types'
 import { defaultConfig } from '../config'
 
-export async function signBytes(
-  data: ArrayBuffer,
-  privateKey: PrivateKey
+
+export async function sign(
+  msg: Msg,
+  privateKey: PrivateKey,
+  charSize: CharSize = DEFAULT_CHAR_SIZE
 ): Promise<ArrayBuffer> {
   return window.crypto.subtle.sign(
     { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
     privateKey,
-    data
+    normalizeUnicodeToBuf(msg, charSize)
   )
 }
 
-export async function signString(
-  msg: string,
-  privateKey: PrivateKey,
-  cfg: Config = defaultConfig
-): Promise<string> {
-  const sigBytes = await signBytes(
-    utils.strToArrBuf(msg, cfg.charSize),
-    privateKey
-  )
-
-  return utils.arrBufToBase64(sigBytes)
-}
-
-export async function verifyBytes(
-  data: ArrayBuffer,
-  sig: ArrayBuffer,
-  publicKey: PublicKey
+export async function verify(
+  msg: Msg,
+  sig: Msg,
+  publicKey: string | PublicKey,
+  charSize: CharSize = DEFAULT_CHAR_SIZE,
+  hashAlg: HashAlg = DEFAULT_HASH_ALG
 ): Promise<boolean> {
   return window.crypto.subtle.verify(
     { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
-    publicKey,
-    sig,
-    data
+    typeof publicKey === "string"
+      ? await keys.importPublicKey(publicKey, hashAlg, KeyUse.Write)
+      : publicKey,
+    normalizeBase64ToBuf(sig),
+    normalizeUnicodeToBuf(msg, charSize)
   )
 }
 
-export async function verifyString(
-  msg: string,
-  sig: string,
-  publicKey64: string,
-  cfg: Config = defaultConfig
-): Promise<boolean> {
-  const publicKey = await keys.importPublicKey(publicKey64, cfg.hashAlg, KeyUse.Write)
-
-  return verifyBytes(
-    utils.strToArrBuf(msg, cfg.charSize),
-    utils.base64ToArrBuf(sig),
-    publicKey
-  )
-}
-
-export async function encryptBytes(
-  data: ArrayBuffer,
-  publicKey: PublicKey
+export async function encrypt(
+  msg: Msg,
+  publicKey: string | PublicKey,
+  charSize: CharSize = DEFAULT_CHAR_SIZE,
+  hashAlg: HashAlg = DEFAULT_HASH_ALG
 ): Promise<CipherText> {
   return window.crypto.subtle.encrypt(
     { name: RSA_READ_ALG },
-    publicKey,
-    data
+    typeof publicKey === "string"
+      ? await keys.importPublicKey(publicKey, hashAlg, KeyUse.Write)
+      : publicKey,
+    normalizeUnicodeToBuf(msg, charSize)
   )
 }
 
-export async function encryptString(
-  msg: string,
-  publicKey64: string,
-  cfg: Config = defaultConfig
-): Promise<string> {
-  const publicKey = await keys.importPublicKey(publicKey64, cfg.hashAlg, KeyUse.Read)
-  const cipherText = await encryptBytes(
-    utils.strToArrBuf(msg, cfg.charSize),
-    publicKey
-  )
-
-  return utils.arrBufToBase64(cipherText)
-}
-
-export async function decryptBytes(
-  cipherText: CipherText,
+export async function decrypt(
+  msg: Msg,
   privateKey: PrivateKey
 ): Promise<ArrayBuffer> {
   return window.crypto.subtle.decrypt(
     { name: RSA_READ_ALG },
     privateKey,
-    cipherText
+    normalizeBase64ToBuf(msg)
   )
-}
-
-export async function decryptString(
-  cipherText: string,
-  privateKey: PrivateKey,
-  cfg: Config = defaultConfig
-): Promise<string> {
-  const msgBytes = await decryptBytes(
-    utils.base64ToArrBuf(cipherText),
-    privateKey
-  )
-
-  return utils.arrBufToStr(msgBytes, cfg.charSize)
 }
 
 export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {

--- a/src/rsa/operations.ts
+++ b/src/rsa/operations.ts
@@ -6,23 +6,23 @@ import { defaultConfig } from '../config'
 
 export async function signBytes(
   data: ArrayBuffer,
-  privKey: PrivateKey
+  privateKey: PrivateKey
 ): Promise<ArrayBuffer> {
   return window.crypto.subtle.sign(
     { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
-    privKey,
+    privateKey,
     data
   )
 }
 
 export async function signString(
   msg: string,
-  privKey: PrivateKey,
-  config: Config = defaultConfig
+  privateKey: PrivateKey,
+  cfg: Config = defaultConfig
 ): Promise<string> {
   const sigBytes = await signBytes(
-    utils.strToArrBuf(msg, config.charSize),
-    privKey
+    utils.strToArrBuf(msg, cfg.charSize),
+    privateKey
   )
 
   return utils.arrBufToBase64(sigBytes)
@@ -31,11 +31,11 @@ export async function signString(
 export async function verifyBytes(
   data: ArrayBuffer,
   sig: ArrayBuffer,
-  pubKey: PublicKey
+  publicKey: PublicKey
 ): Promise<boolean> {
   return window.crypto.subtle.verify(
     { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
-    pubKey,
+    publicKey,
     sig,
     data
   )
@@ -43,40 +43,39 @@ export async function verifyBytes(
 
 export async function verifyString(
   msg: string,
-  signature: string,
-  publicKey: string,
-  config: Config = defaultConfig
+  sig: string,
+  publicKey64: string,
+  cfg: Config = defaultConfig
 ): Promise<boolean> {
-  const pubKey = await keys.importPublicKey(publicKey, config.hashAlg, KeyUse.Write)
+  const publicKey = await keys.importPublicKey(publicKey64, cfg.hashAlg, KeyUse.Write)
 
   return verifyBytes(
-    utils.strToArrBuf(msg, config.charSize),
-    utils.base64ToArrBuf(signature),
-    pubKey
+    utils.strToArrBuf(msg, cfg.charSize),
+    utils.base64ToArrBuf(sig),
+    publicKey
   )
 }
 
 export async function encryptBytes(
   data: ArrayBuffer,
-  pubKey: PublicKey
+  publicKey: PublicKey
 ): Promise<CipherText> {
   return window.crypto.subtle.encrypt(
     { name: RSA_READ_ALG },
-    pubKey,
+    publicKey,
     data
   )
 }
 
 export async function encryptString(
   msg: string,
-  publicKey: string,
-  config: Config = defaultConfig
+  publicKey64: string,
+  cfg: Config = defaultConfig
 ): Promise<string> {
-  const pubKey = await keys.importPublicKey(publicKey, config.hashAlg, KeyUse.Read)
-
+  const publicKey = await keys.importPublicKey(publicKey64, cfg.hashAlg, KeyUse.Read)
   const cipherText = await encryptBytes(
-    utils.strToArrBuf(msg, config.charSize),
-    pubKey
+    utils.strToArrBuf(msg, cfg.charSize),
+    publicKey
   )
 
   return utils.arrBufToBase64(cipherText)
@@ -96,14 +95,14 @@ export async function decryptBytes(
 export async function decryptString(
   cipherText: string,
   privateKey: PrivateKey,
-  config: Config = defaultConfig
+  cfg: Config = defaultConfig
 ): Promise<string> {
   const msgBytes = await decryptBytes(
     utils.base64ToArrBuf(cipherText),
     privateKey
   )
 
-  return utils.arrBufToStr(msgBytes, config.charSize)
+  return utils.arrBufToStr(msgBytes, cfg.charSize)
 }
 
 export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {

--- a/src/rsa/operations.ts
+++ b/src/rsa/operations.ts
@@ -1,8 +1,7 @@
 import keys from './keys'
 import utils, { normalizeBase64ToBuf, normalizeUnicodeToBuf } from '../utils'
 import { DEFAULT_CHAR_SIZE, DEFAULT_HASH_ALG, RSA_READ_ALG, RSA_WRITE_ALG, SALT_LENGTH } from '../constants'
-import { CharSize, Config, HashAlg, KeyUse, Msg, PrivateKey, PublicKey, CipherText } from '../types'
-import { defaultConfig } from '../config'
+import { CharSize, HashAlg, KeyUse, Msg, PrivateKey, PublicKey } from '../types'
 
 
 export async function sign(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type Msg = ArrayBuffer | string | Uint8Array
+
 export type CipherText = ArrayBuffer
 export type SymmKey = CryptoKey
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { CharSize } from './types'
+import { CharSize, Msg } from './types'
 
 export function arrBufToStr(buf: ArrayBuffer, charSize: CharSize): string {
   const arr = charSize === 8 ? new Uint8Array(buf) : new Uint16Array(buf)
@@ -45,6 +45,18 @@ export function joinBufs(fst: ArrayBuffer, snd: ArrayBuffer): ArrayBuffer {
   return joined.buffer
 }
 
+export const normalizeToBuf = (msg: Msg): ArrayBuffer => {
+  if (msg instanceof ArrayBuffer) {
+    return msg
+  } else if (msg instanceof Uint8Array) {
+    return msg.buffer
+  } else if (typeof msg === 'string') {
+    return strToArrBuf(msg, CharSize.B16)
+  } else {
+    throw new Error("Improper value. Must be a string, ArrayBuffer, Uint8Array, or Uint16Array")
+  }
+}
+
 /* istanbul ignore next */
 export async function structuralClone(obj: any) {
   return new Promise(resolve => {
@@ -62,5 +74,6 @@ export default {
   publicExponent,
   randomBuf,
   joinBufs,
+  normalizeToBuf,
   structuralClone
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,10 @@ export function joinBufs(fst: ArrayBuffer, snd: ArrayBuffer): ArrayBuffer {
   return joined.buffer
 }
 
+export const normalizeUtf8ToBuf = (msg: Msg): ArrayBuffer => {
+  return normalizeToBuf(msg, (str) => strToArrBuf(str, CharSize.B8))
+}
+
 export const normalizeUtf16ToBuf = (msg: Msg): ArrayBuffer => {
   return normalizeToBuf(msg, (str) => strToArrBuf(str, CharSize.B16))
 }
@@ -53,10 +57,18 @@ export const normalizeBase64ToBuf = (msg: Msg): ArrayBuffer => {
   return normalizeToBuf(msg, base64ToArrBuf)
 }
 
+export const normalizeUnicodeToBuf = (msg: Msg, charSize: CharSize) => {
+  switch (charSize) {
+    case 8: return normalizeUtf8ToBuf(msg)
+    default: return normalizeUtf16ToBuf(msg)
+  }
+}
+
 export const normalizeToBuf = (msg: Msg, strConv: (str: string) => ArrayBuffer): ArrayBuffer => {
   if (typeof msg === 'string') {
     return strConv(msg)
-  } else if(typeof msg === 'object' && msg.byteLength !== undefined) { // this is the best runtime check I could find for ArrayBuffer/Uint8Array  
+  } else if (typeof msg === 'object' && msg.byteLength !== undefined) {
+    // this is the best runtime check I could find for ArrayBuffer/Uint8Array
     const temp = new Uint8Array(msg)
     return temp.buffer
   } else {
@@ -81,6 +93,7 @@ export default {
   publicExponent,
   randomBuf,
   joinBufs,
+  normalizeUtf8ToBuf,
   normalizeUtf16ToBuf,
   normalizeBase64ToBuf,
   normalizeToBuf,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,11 +45,11 @@ export function joinBufs(fst: ArrayBuffer, snd: ArrayBuffer): ArrayBuffer {
   return joined.buffer
 }
 
-export const normalizeTextToBuf = (msg: Msg): ArrayBuffer => {
+export const normalizeUtf16ToBuf = (msg: Msg): ArrayBuffer => {
   return normalizeToBuf(msg, (str) => strToArrBuf(str, CharSize.B16))
 }
 
-export const normalizeCipherToBuf = (msg: Msg): ArrayBuffer => {
+export const normalizeBase64ToBuf = (msg: Msg): ArrayBuffer => {
   return normalizeToBuf(msg, base64ToArrBuf)
 }
 
@@ -81,8 +81,8 @@ export default {
   publicExponent,
   randomBuf,
   joinBufs,
-  normalizeTextToBuf,
-  normalizeCipherToBuf,
+  normalizeUtf16ToBuf,
+  normalizeBase64ToBuf,
   normalizeToBuf,
   structuralClone
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,15 +45,22 @@ export function joinBufs(fst: ArrayBuffer, snd: ArrayBuffer): ArrayBuffer {
   return joined.buffer
 }
 
-export const normalizeToBuf = (msg: Msg): ArrayBuffer => {
-  if (msg instanceof ArrayBuffer) {
-    return msg
-  } else if (msg instanceof Uint8Array) {
-    return msg.buffer
-  } else if (typeof msg === 'string') {
-    return strToArrBuf(msg, CharSize.B16)
+export const normalizeTextToBuf = (msg: Msg): ArrayBuffer => {
+  return normalizeToBuf(msg, (str) => strToArrBuf(str, CharSize.B16))
+}
+
+export const normalizeCipherToBuf = (msg: Msg): ArrayBuffer => {
+  return normalizeToBuf(msg, base64ToArrBuf)
+}
+
+export const normalizeToBuf = (msg: Msg, strConv: (str: string) => ArrayBuffer): ArrayBuffer => {
+  if (typeof msg === 'string') {
+    return strConv(msg)
+  } else if(typeof msg === 'object' && msg.byteLength !== undefined) { // this is the best runtime check I could find for ArrayBuffer/Uint8Array  
+    const temp = new Uint8Array(msg)
+    return temp.buffer
   } else {
-    throw new Error("Improper value. Must be a string, ArrayBuffer, Uint8Array, or Uint16Array")
+    throw new Error("Improper value. Must be a string, ArrayBuffer, Uint8Array")
   }
 }
 
@@ -74,6 +81,8 @@ export default {
   publicExponent,
   randomBuf,
   joinBufs,
+  normalizeTextToBuf,
+  normalizeCipherToBuf,
   normalizeToBuf,
   structuralClone
 }

--- a/test/ecc.keystore.test.ts
+++ b/test/ecc.keystore.test.ts
@@ -1,7 +1,7 @@
 import ECCKeyStore from '../src/ecc/keystore'
 import keys from '../src/ecc/keys'
 import operations from '../src/ecc/operations'
-import config from '../src/config'
+import config, { defaultConfig } from '../src/config'
 import idb from '../src/idb'
 import { EccCurve, KeyUse, CryptoSystem } from '../src/types'
 import { mock, keystoreMethod } from './utils'
@@ -74,12 +74,12 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'signBytes', 
-        resp: mock.sigBytes,
+        meth: 'signString',
+        resp: mock.sigStr,
         params: [
-          mock.msgBytes,
+          mock.msgStr,
           mock.writeKeys.privateKey,
-          config.defaultConfig.hashAlg
+          defaultConfig
         ]
       }
     ],
@@ -94,23 +94,13 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'verifyBytes', 
+        meth: 'verifyString',
         resp: true,
         params: [
-          mock.msgBytes,
-          mock.sigBytes,
-          mock.writeKeys.publicKey,
-          config.defaultConfig.hashAlg
-        ]
-      },
-      {
-        mod: keys,
-        meth: 'importPublicKey',
-        resp: mock.writeKeys.publicKey,
-        params: [
+          mock.msgStr,
+          mock.sigStr,
           mock.keyBase64,
-          config.defaultConfig.curve,
-          KeyUse.Write
+          defaultConfig
         ]
       }
     ],
@@ -125,26 +115,13 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'encryptBytes', 
-        resp: mock.cipherBytes,
+        meth: 'encryptString',
+        resp: mock.cipherStr,
         params: [
-          mock.msgBytes,
+          mock.msgStr,
           mock.keys.privateKey,
-          mock.encryptForKey.publicKey,
-          {
-            alg: config.defaultConfig.symmAlg,
-            length: config.defaultConfig.symmLen
-          }
-        ]
-      },
-      {
-        mod: keys,
-        meth: 'importPublicKey',
-        resp: mock.encryptForKey.publicKey,
-        params: [
           mock.keyBase64,
-          config.defaultConfig.curve,
-          KeyUse.Read
+          defaultConfig
         ]
       }
     ],
@@ -159,26 +136,13 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'decryptBytes', 
-        resp: mock.msgBytes,
+        meth: 'decryptString',
+        resp: mock.msgStr,
         params: [
-          mock.cipherBytes,
+          mock.cipherStr,
           mock.keys.privateKey,
-          mock.encryptForKey.publicKey,
-          {
-            alg: config.defaultConfig.symmAlg,
-            length: config.defaultConfig.symmLen
-          }
-        ]
-      },
-      {
-        mod: keys,
-        meth: 'importPublicKey',
-        resp: mock.encryptForKey.publicKey,
-        params: [
           mock.keyBase64,
-          config.defaultConfig.curve,
-          KeyUse.Read
+          defaultConfig
         ]
       }
     ],
@@ -193,7 +157,7 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'getPublicKey', 
+        meth: 'getPublicKey',
         resp: mock.keyBase64,
         params: [
           mock.keys
@@ -211,7 +175,7 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'getPublicKey', 
+        meth: 'getPublicKey',
         resp: mock.keyBase64,
         params: [
           mock.writeKeys

--- a/test/ecc.keystore.test.ts
+++ b/test/ecc.keystore.test.ts
@@ -3,7 +3,7 @@ import keys from '../src/ecc/keys'
 import operations from '../src/ecc/operations'
 import config, { defaultConfig } from '../src/config'
 import idb from '../src/idb'
-import { DEFAULT_CHAR_SIZE, DEFAULT_EccCurve, DEFAULT_HASH_ALG } from '../src/constants'
+import { DEFAULT_CHAR_SIZE, DEFAULT_ECC_CURVE, DEFAULT_HASH_ALG } from '../src/constants'
 import { EccCurve, KeyUse, CryptoSystem } from '../src/types'
 import { mock, keystoreMethod } from './utils'
 
@@ -103,7 +103,7 @@ describe("ECCKeyStore", () => {
           mock.sigStr,
           mock.keyBase64,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve,
+          DEFAULT_ECC_CURVE,
           DEFAULT_HASH_ALG
         ]
       }
@@ -126,7 +126,7 @@ describe("ECCKeyStore", () => {
           mock.keys.privateKey,
           mock.keyBase64,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve
+          DEFAULT_ECC_CURVE
         ]
       }
     ],
@@ -148,7 +148,7 @@ describe("ECCKeyStore", () => {
           mock.keys.privateKey,
           mock.keyBase64,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve
+          DEFAULT_ECC_CURVE
         ]
       }
     ],

--- a/test/ecc.keystore.test.ts
+++ b/test/ecc.keystore.test.ts
@@ -3,6 +3,7 @@ import keys from '../src/ecc/keys'
 import operations from '../src/ecc/operations'
 import config, { defaultConfig } from '../src/config'
 import idb from '../src/idb'
+import { DEFAULT_CHAR_SIZE, DEFAULT_EccCurve, DEFAULT_HASH_ALG } from '../src/constants'
 import { EccCurve, KeyUse, CryptoSystem } from '../src/types'
 import { mock, keystoreMethod } from './utils'
 
@@ -74,12 +75,13 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'signString',
-        resp: mock.sigStr,
+        meth: 'sign',
+        resp: mock.sigBytes,
         params: [
           mock.msgStr,
           mock.writeKeys.privateKey,
-          defaultConfig
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_HASH_ALG
         ]
       }
     ],
@@ -94,13 +96,15 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'verifyString',
+        meth: 'verify',
         resp: true,
         params: [
           mock.msgStr,
           mock.sigStr,
           mock.keyBase64,
-          defaultConfig
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve,
+          DEFAULT_HASH_ALG
         ]
       }
     ],
@@ -115,13 +119,14 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'encryptString',
-        resp: mock.cipherStr,
+        meth: 'encrypt',
+        resp: mock.cipherBytes,
         params: [
           mock.msgStr,
           mock.keys.privateKey,
           mock.keyBase64,
-          defaultConfig
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve
         ]
       }
     ],
@@ -136,13 +141,14 @@ describe("ECCKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'decryptString',
-        resp: mock.msgStr,
+        meth: 'decrypt',
+        resp: mock.msgBytes,
         params: [
           mock.cipherStr,
           mock.keys.privateKey,
           mock.keyBase64,
-          defaultConfig
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve
         ]
       }
     ],

--- a/test/ecc.test.ts
+++ b/test/ecc.test.ts
@@ -1,7 +1,7 @@
 import ecc from '../src/ecc'
 import errors from '../src/errors'
 import utils from '../src/utils'
-import { DEFAULT_CHAR_SIZE, DEFAULT_EccCurve } from '../src/constants'
+import { DEFAULT_CHAR_SIZE, DEFAULT_ECC_CURVE } from '../src/constants'
 import { KeyUse, EccCurve, HashAlg, SymmAlg, SymmKeyLength } from '../src/types'
 import { mock, cryptoMethod, arrBufEq } from './utils'
 
@@ -150,7 +150,7 @@ describe('ecc', () => {
           mock.sigBytes,
           mock.keys.publicKey,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve,
+          DEFAULT_ECC_CURVE,
           HashAlg.SHA_512
         ),
         params: (params: any) => params[0]?.hash?.name === 'SHA-512'
@@ -169,7 +169,7 @@ describe('ecc', () => {
       mock.sigStr,
       mock.keyBase64,
       DEFAULT_CHAR_SIZE,
-      DEFAULT_EccCurve,
+      DEFAULT_ECC_CURVE,
       HashAlg.SHA_256
     ),
     simpleParams: [
@@ -212,7 +212,7 @@ describe('ecc', () => {
           mock.keys.privateKey,
           mock.keys.publicKey,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve,
+          DEFAULT_ECC_CURVE,
           { alg: SymmAlg.AES_CBC }
         ),
         params: (params: any) => params[0]?.name === 'AES-CBC'
@@ -224,7 +224,7 @@ describe('ecc', () => {
           mock.keys.privateKey,
           mock.keys.publicKey,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve,
+          DEFAULT_ECC_CURVE,
           { length: SymmKeyLength.B256 }
         ),
         params: (params: any) => params[0]?.length === 256
@@ -236,7 +236,7 @@ describe('ecc', () => {
           mock.keys.privateKey,
           mock.keys.publicKey,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve,
+          DEFAULT_ECC_CURVE,
           { iv: mock.iv }
         ),
         params: (params: any) => arrBufEq(params[0]?.counter, mock.iv)
@@ -248,7 +248,7 @@ describe('ecc', () => {
           mock.keys.privateKey,
           mock.keys.publicKey,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve,
+          DEFAULT_ECC_CURVE,
           { alg: SymmAlg.AES_CBC, iv: mock.iv }
         ),
         params: (params: any) => params[0]?.iv === mock.iv
@@ -271,7 +271,7 @@ describe('ecc', () => {
       mock.keys.privateKey,
       mock.keyBase64,
       DEFAULT_CHAR_SIZE,
-      DEFAULT_EccCurve
+      DEFAULT_ECC_CURVE
     ),
     simpleParams: [
       { name: 'AES-CTR',
@@ -321,7 +321,7 @@ describe('ecc', () => {
           mock.keys.privateKey,
           mock.keys.publicKey,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve,
+          DEFAULT_ECC_CURVE,
           { alg: SymmAlg.AES_CBC }
         ),
         params: (params: any) => (
@@ -337,7 +337,7 @@ describe('ecc', () => {
           mock.keys.privateKey,
           mock.keys.publicKey,
           DEFAULT_CHAR_SIZE,
-          DEFAULT_EccCurve,
+          DEFAULT_ECC_CURVE,
           { length: SymmKeyLength.B256 }
         ),
         params: (params: any) => params[0]?.length === 256
@@ -359,7 +359,7 @@ describe('ecc', () => {
       mock.keys.privateKey,
       mock.keyBase64,
       DEFAULT_CHAR_SIZE,
-      DEFAULT_EccCurve
+      DEFAULT_ECC_CURVE
     ),
     paramChecks: [],
     shouldThrows: []

--- a/test/ecc.test.ts
+++ b/test/ecc.test.ts
@@ -1,6 +1,7 @@
 import ecc from '../src/ecc'
 import errors from '../src/errors'
 import utils from '../src/utils'
+import { DEFAULT_CHAR_SIZE, DEFAULT_EccCurve } from '../src/constants'
 import { KeyUse, EccCurve, HashAlg, SymmAlg, SymmKeyLength } from '../src/types'
 import { mock, cryptoMethod, arrBufEq } from './utils'
 
@@ -78,19 +79,27 @@ describe('ecc', () => {
 
 
   cryptoMethod({
-    desc: 'signBytes',
+    desc: 'sign',
     setMock: fake => window.crypto.subtle.sign = fake,
     mockResp: mock.sigBytes,
-    simpleReq: () => ecc.signBytes(mock.msgBytes, mock.keys.privateKey, HashAlg.SHA_256),
+    simpleReq: () => ecc.sign(
+      mock.msgBytes,
+      mock.keys.privateKey
+    ),
     simpleParams: [
-      { name: 'ECDSA', hash: {name: 'SHA-256' }},
+      { name: 'ECDSA', hash: { name: 'SHA-256' }},
       mock.keys.privateKey,
       mock.msgBytes
     ],
     paramChecks: [
       {
         desc: 'handles multiple hash algorithms',
-        req: () => ecc.signBytes(mock.msgBytes, mock.keys.privateKey, HashAlg.SHA_512),
+        req: () => ecc.sign(
+          mock.msgBytes,
+          mock.keys.privateKey,
+          DEFAULT_CHAR_SIZE,
+          HashAlg.SHA_512
+        ),
         params: (params: any) => params[0]?.hash?.name === 'SHA-512'
       },
     ],
@@ -99,12 +108,36 @@ describe('ecc', () => {
 
 
   cryptoMethod({
-    desc: 'verifyBytes',
+    desc: 'sign',
+    setMock: fake => window.crypto.subtle.sign = fake,
+    mockResp: mock.sigBytes,
+    simpleReq: () => ecc.sign(
+      mock.msgStr,
+      mock.keys.privateKey,
+      DEFAULT_CHAR_SIZE,
+      HashAlg.SHA_256
+    ),
+    simpleParams: [
+      { name: 'ECDSA', hash: { name: 'SHA-256' }},
+      mock.keys.privateKey,
+      mock.msgBytes
+    ],
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'verify',
     setMock: fake => window.crypto.subtle.verify = fake,
     mockResp: true,
-    simpleReq: () => ecc.verifyBytes(mock.msgBytes, mock.sigBytes, mock.keys.publicKey, HashAlg.SHA_256),
+    simpleReq: () => ecc.verify(
+      mock.msgBytes,
+      mock.sigBytes,
+      mock.keys.publicKey
+    ),
     simpleParams: [
-      { name: 'ECDSA', hash: {name: 'SHA-256' }},
+      { name: 'ECDSA', hash: { name: 'SHA-256' }},
       mock.keys.publicKey,
       mock.sigBytes,
       mock.msgBytes
@@ -112,10 +145,238 @@ describe('ecc', () => {
     paramChecks: [
       {
         desc: 'handles multiple hash algorithms',
-        req: () => ecc.verifyBytes(mock.msgBytes, mock.sigBytes, mock.keys.publicKey, HashAlg.SHA_512),
+        req: () => ecc.verify(
+          mock.msgBytes,
+          mock.sigBytes,
+          mock.keys.publicKey,
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve,
+          HashAlg.SHA_512
+        ),
         params: (params: any) => params[0]?.hash?.name === 'SHA-512'
       }
     ],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'verify',
+    setMock: fake => window.crypto.subtle.verify = fake,
+    mockResp: true,
+    simpleReq: () => ecc.verify(
+      mock.msgStr,
+      mock.sigStr,
+      mock.keyBase64,
+      DEFAULT_CHAR_SIZE,
+      DEFAULT_EccCurve,
+      HashAlg.SHA_256
+    ),
+    simpleParams: [
+      { name: 'ECDSA', hash: { name: 'SHA-256' }},
+      mock.keys.publicKey,
+      mock.sigBytes,
+      mock.msgBytes
+    ],
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'encrypt',
+    setMock: fake => {
+      window.crypto.subtle.encrypt = fake
+      window.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+      window.crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
+    },
+    mockResp: mock.cipherBytes,
+    simpleReq: () => ecc.encrypt(
+      mock.msgBytes,
+      mock.keys.privateKey,
+      mock.keys.publicKey
+    ),
+    simpleParams: [
+      { name: 'AES-CTR',
+        counter: new Uint8Array(16),
+        length: 128
+      },
+      mock.symmKey,
+      mock.msgBytes
+    ],
+    paramChecks: [
+      {
+        desc: 'handles multiple symm key algorithms',
+        req: () => ecc.encrypt(
+          mock.msgBytes,
+          mock.keys.privateKey,
+          mock.keys.publicKey,
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve,
+          { alg: SymmAlg.AES_CBC }
+        ),
+        params: (params: any) => params[0]?.name === 'AES-CBC'
+      },
+      {
+        desc: 'handles multiple symm key lengths',
+        req: () => ecc.encrypt(
+          mock.msgBytes,
+          mock.keys.privateKey,
+          mock.keys.publicKey,
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve,
+          { length: SymmKeyLength.B256 }
+        ),
+        params: (params: any) => params[0]?.length === 256
+      },
+      {
+        desc: 'handles an IV with AES-CTR',
+        req: () => ecc.encrypt(
+          mock.msgBytes,
+          mock.keys.privateKey,
+          mock.keys.publicKey,
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve,
+          { iv: mock.iv }
+        ),
+        params: (params: any) => arrBufEq(params[0]?.counter, mock.iv)
+      },
+      {
+        desc: 'handles an IV with AES-CBC',
+        req: () => ecc.encrypt(
+          mock.msgBytes,
+          mock.keys.privateKey,
+          mock.keys.publicKey,
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve,
+          { alg: SymmAlg.AES_CBC, iv: mock.iv }
+        ),
+        params: (params: any) => params[0]?.iv === mock.iv
+      }
+    ],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'encrypt',
+    setMock: fake => {
+      window.crypto.subtle.encrypt = fake
+      window.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+      window.crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
+    },
+    mockResp: mock.cipherBytes,
+    simpleReq: () => ecc.encrypt(
+      mock.msgStr,
+      mock.keys.privateKey,
+      mock.keyBase64,
+      DEFAULT_CHAR_SIZE,
+      DEFAULT_EccCurve
+    ),
+    simpleParams: [
+      { name: 'AES-CTR',
+        counter: new Uint8Array(16),
+        length: 128
+      },
+      mock.symmKey,
+      mock.msgBytes
+    ],
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'decrypt',
+    setMock: fake => {
+      window.crypto.subtle.decrypt = fake
+      window.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+    },
+    mockResp: mock.msgBytes,
+    simpleReq: () => ecc.decrypt(
+      mock.cipherWithIVBytes,
+      mock.keys.privateKey,
+      mock.keys.publicKey
+    ),
+    paramChecks: [
+      {
+        desc: 'correctly passes params with AES-CTR',
+        req: () => ecc.decrypt(
+          mock.cipherWithIVBytes,
+          mock.keys.privateKey,
+          mock.keys.publicKey
+        ),
+        params: (params: any) => (
+          params[0].name === 'AES-CTR'
+          && params[0].length === 128
+          && arrBufEq(params[0].counter.buffer, mock.iv)
+          && params[1] === mock.symmKey
+          && arrBufEq(params[2], mock.cipherBytes)
+        )
+      },
+      {
+        desc: 'correctly passes params with AES-CBC',
+        req: () => ecc.decrypt(
+          mock.cipherWithIVBytes,
+          mock.keys.privateKey,
+          mock.keys.publicKey,
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve,
+          { alg: SymmAlg.AES_CBC }
+        ),
+        params: (params: any) => (
+          params[0]?.name === 'AES-CBC'
+          && arrBufEq(params[0].iv, mock.iv)
+          && arrBufEq(params[2], mock.cipherBytes)
+        )
+      },
+      {
+        desc: 'handles multiple symm key lengths',
+        req: () => ecc.decrypt(
+          mock.cipherWithIVBytes,
+          mock.keys.privateKey,
+          mock.keys.publicKey,
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_EccCurve,
+          { length: SymmKeyLength.B256 }
+        ),
+        params: (params: any) => params[0]?.length === 256
+      },
+    ],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'decrypt',
+    setMock: fake => {
+      window.crypto.subtle.decrypt = fake
+      window.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+    },
+    mockResp: mock.msgBytes,
+    simpleReq: () => ecc.decrypt(
+      mock.cipherWithIVStr,
+      mock.keys.privateKey,
+      mock.keyBase64,
+      DEFAULT_CHAR_SIZE,
+      DEFAULT_EccCurve
+    ),
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'getPublicKey',
+    setMock: fake => window.crypto.subtle.exportKey = fake,
+    mockResp: utils.base64ToArrBuf(mock.keyBase64),
+    expectedResp: mock.keyBase64,
+    simpleReq: () => ecc.getPublicKey(mock.keys),
+    simpleParams: [
+      'raw',
+      mock.keys.publicKey
+    ],
+    paramChecks: [],
     shouldThrows: []
   })
 
@@ -144,103 +405,6 @@ describe('ecc', () => {
         params: (params: any) => params[2]?.length === 256
       }
     ],
-    shouldThrows: []
-  })
-
-
-  cryptoMethod({
-    desc: 'encryptBytes',
-    setMock: fake => {
-      window.crypto.subtle.encrypt = fake
-      window.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
-      window.crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
-    },
-    mockResp: mock.cipherBytes,
-    simpleReq: () => ecc.encryptBytes(mock.msgBytes, mock.keys.privateKey, mock.keys.publicKey),
-    simpleParams: [
-      { name: 'AES-CTR',
-        counter: new Uint8Array(16),
-        length: 128
-      },
-      mock.symmKey,
-      mock.msgBytes
-    ],
-    paramChecks: [
-      {
-        desc: 'handles multiple symm key algorithms',
-        req: () => ecc.encryptBytes(mock.msgBytes, mock.keys.privateKey, mock.keys.publicKey, { alg: SymmAlg.AES_CBC }),
-        params: (params: any) => params[0]?.name === 'AES-CBC'
-      },
-      {
-        desc: 'handles multiple symm key lengths',
-        req: () => ecc.encryptBytes(mock.msgBytes, mock.keys.privateKey, mock.keys.publicKey, { length: SymmKeyLength.B256 }),
-        params: (params: any) => params[0]?.length === 256
-      },
-      {
-        desc: 'handles an IV with AES-CTR',
-        req: () => ecc.encryptBytes(mock.msgBytes, mock.keys.privateKey, mock.keys.publicKey, { iv: mock.iv }),
-        params: (params: any) => arrBufEq(params[0]?.counter, mock.iv)
-      },
-      {
-        desc: 'handles an IV with AES-CBC',
-        req: () => ecc.encryptBytes(mock.msgBytes, mock.keys.privateKey, mock.keys.publicKey, { alg: SymmAlg.AES_CBC, iv: mock.iv }),
-        params: (params: any) => params[0]?.iv === mock.iv
-      }
-    ],
-    shouldThrows: []
-  })
-
-
-  cryptoMethod({
-    desc: 'decryptBytes',
-    setMock: fake => {
-      window.crypto.subtle.decrypt = fake
-      window.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
-    },
-    mockResp: mock.msgBytes,
-    simpleReq: () => ecc.decryptBytes(mock.cipherWithIVBytes, mock.keys.privateKey, mock.keys.publicKey),
-    paramChecks: [
-      {
-        desc: 'correctly passes params with AES-CTR',
-        req: () => ecc.decryptBytes(mock.cipherWithIVBytes, mock.keys.privateKey, mock.keys.publicKey),
-        params: (params: any) => (
-          params[0].name === 'AES-CTR'
-          && params[0].length === 128 
-          && arrBufEq(params[0].counter.buffer, mock.iv)
-          && params[1] === mock.symmKey 
-          && arrBufEq(params[2], mock.cipherBytes)
-        )
-      },
-      {
-        desc: 'correctly passes params with AES-CBC',
-        req: () => ecc.decryptBytes(mock.cipherWithIVBytes, mock.keys.privateKey, mock.keys.publicKey, { alg: SymmAlg.AES_CBC }),
-        params: (params: any) => (
-          params[0]?.name === 'AES-CBC'
-          && arrBufEq(params[0].iv, mock.iv)
-          && arrBufEq(params[2], mock.cipherBytes)
-        )
-      },
-      {
-        desc: 'handles multiple symm key lengths',
-        req: () => ecc.decryptBytes(mock.cipherWithIVBytes, mock.keys.privateKey, mock.keys.publicKey, { length: SymmKeyLength.B256 }),
-        params: (params: any) => params[0]?.length === 256
-      },
-    ],
-    shouldThrows: []
-  })
-
-
-  cryptoMethod({
-    desc: 'getPublicKey',
-    setMock: fake => window.crypto.subtle.exportKey = fake,
-    mockResp: utils.base64ToArrBuf(mock.keyBase64),
-    expectedResp: mock.keyBase64,
-    simpleReq: () => ecc.getPublicKey(mock.keys),
-    simpleParams: [
-      'raw',
-      mock.keys.publicKey
-    ],
-    paramChecks: [],
     shouldThrows: []
   })
 

--- a/test/rsa.keystore.test.ts
+++ b/test/rsa.keystore.test.ts
@@ -1,7 +1,7 @@
 import RSAKeyStore from '../src/rsa/keystore'
 import keys from '../src/rsa/keys'
 import operations from '../src/rsa/operations'
-import config from '../src/config'
+import config, { defaultConfig } from '../src/config'
 import idb from '../src/idb'
 import { KeyUse, RsaSize, HashAlg, CryptoSystem } from '../src/types'
 import { mock, keystoreMethod } from './utils'
@@ -76,11 +76,12 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'signBytes', 
-        resp: mock.sigBytes,
+        meth: 'signString',
+        resp: mock.sigStr,
         params: [
-          mock.msgBytes,
+          mock.msgStr,
           mock.writeKeys.privateKey,
+          defaultConfig
         ]
       }
     ],
@@ -95,22 +96,13 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'verifyBytes', 
+        meth: 'verifyString',
         resp: true,
         params: [
-          mock.msgBytes,
-          mock.sigBytes,
-          mock.writeKeys.publicKey,
-        ]
-      },
-      {
-        mod: keys,
-        meth: 'importPublicKey',
-        resp: mock.writeKeys.publicKey,
-        params: [
+          mock.msgStr,
+          mock.sigStr,
           mock.keyBase64,
-          config.defaultConfig.hashAlg,
-          KeyUse.Write
+          defaultConfig
         ]
       }
     ],
@@ -125,21 +117,12 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'encryptBytes', 
-        resp: mock.cipherBytes,
+        meth: 'encryptString',
+        resp: mock.cipherStr,
         params: [
-          mock.msgBytes,
-          mock.encryptForKey.publicKey,
-        ]
-      },
-      {
-        mod: keys,
-        meth: 'importPublicKey',
-        resp: mock.encryptForKey.publicKey,
-        params: [
+          mock.msgStr,
           mock.keyBase64,
-          config.defaultConfig.hashAlg,
-          KeyUse.Read
+          defaultConfig
         ]
       }
     ],
@@ -154,11 +137,12 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'decryptBytes', 
-        resp: mock.msgBytes,
+        meth: 'decryptString',
+        resp: mock.msgStr,
         params: [
-          mock.cipherBytes,
+          mock.cipherStr,
           mock.keys.privateKey,
+          defaultConfig
         ]
       },
     ],
@@ -173,7 +157,7 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'getPublicKey', 
+        meth: 'getPublicKey',
         resp: mock.keyBase64,
         params: [
           mock.keys
@@ -191,7 +175,7 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'getPublicKey', 
+        meth: 'getPublicKey',
         resp: mock.keyBase64,
         params: [
           mock.writeKeys

--- a/test/rsa.keystore.test.ts
+++ b/test/rsa.keystore.test.ts
@@ -3,6 +3,7 @@ import keys from '../src/rsa/keys'
 import operations from '../src/rsa/operations'
 import config, { defaultConfig } from '../src/config'
 import idb from '../src/idb'
+import { DEFAULT_CHAR_SIZE, DEFAULT_HASH_ALG } from '../src/constants'
 import { KeyUse, RsaSize, HashAlg, CryptoSystem } from '../src/types'
 import { mock, keystoreMethod } from './utils'
 
@@ -76,12 +77,12 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'signString',
-        resp: mock.sigStr,
+        meth: 'sign',
+        resp: mock.sigBytes,
         params: [
           mock.msgStr,
           mock.writeKeys.privateKey,
-          defaultConfig
+          DEFAULT_CHAR_SIZE
         ]
       }
     ],
@@ -96,13 +97,14 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'verifyString',
+        meth: 'verify',
         resp: true,
         params: [
           mock.msgStr,
           mock.sigStr,
           mock.keyBase64,
-          defaultConfig
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_HASH_ALG
         ]
       }
     ],
@@ -117,12 +119,13 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'encryptString',
-        resp: mock.cipherStr,
+        meth: 'encrypt',
+        resp: mock.cipherBytes,
         params: [
           mock.msgStr,
           mock.keyBase64,
-          defaultConfig
+          DEFAULT_CHAR_SIZE,
+          DEFAULT_HASH_ALG
         ]
       }
     ],
@@ -137,12 +140,12 @@ describe("RSAKeyStore", () => {
     mocks: [
       {
         mod: operations,
-        meth: 'decryptString',
-        resp: mock.msgStr,
+        meth: 'decrypt',
+        resp: mock.msgBytes,
         params: [
           mock.cipherStr,
           mock.keys.privateKey,
-          defaultConfig
+          DEFAULT_CHAR_SIZE
         ]
       },
     ],

--- a/test/rsa.test.ts
+++ b/test/rsa.test.ts
@@ -1,6 +1,7 @@
 import rsa from '../src/rsa'
 import errors from '../src/errors'
 import utils from '../src/utils'
+import { DEFAULT_CHAR_SIZE, DEFAULT_HASH_ALG } from '../src/constants'
 import { KeyUse, RsaSize, HashAlg } from '../src/types'
 import { mock, cryptoMethod } from './utils'
 
@@ -93,12 +94,15 @@ describe('rsa', () => {
 
 
   cryptoMethod({
-    desc: 'signBytes',
+    desc: 'sign',
     setMock: fake => window.crypto.subtle.sign = fake,
     mockResp: mock.sigBytes,
-    simpleReq: () => rsa.signBytes(mock.msgBytes, mock.keys.privateKey),
+    simpleReq: () => rsa.sign(
+      mock.msgBytes,
+      mock.keys.privateKey
+    ),
     simpleParams: [
-      { name: 'RSASSA-PKCS1-v1_5', saltLength: 128},
+      { name: 'RSASSA-PKCS1-v1_5', saltLength: 128 },
       mock.keys.privateKey,
       mock.msgBytes
     ],
@@ -108,12 +112,35 @@ describe('rsa', () => {
 
 
   cryptoMethod({
-    desc: 'verifyBytes',
+    desc: 'sign',
+    setMock: fake => window.crypto.subtle.sign = fake,
+    mockResp: mock.sigBytes,
+    simpleReq: () => rsa.sign(
+      mock.msgStr,
+      mock.keys.privateKey,
+      DEFAULT_CHAR_SIZE
+    ),
+    simpleParams: [
+      { name: 'RSASSA-PKCS1-v1_5', saltLength: 128 },
+      mock.keys.privateKey,
+      mock.msgBytes
+    ],
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'verify',
     setMock: fake => window.crypto.subtle.verify = fake,
     mockResp: true,
-    simpleReq: () => rsa.verifyBytes(mock.msgBytes, mock.sigBytes, mock.keys.publicKey),
+    simpleReq: () => rsa.verify(
+      mock.msgBytes,
+      mock.sigBytes,
+      mock.keys.publicKey
+    ),
     simpleParams: [
-      { name: 'RSASSA-PKCS1-v1_5', saltLength: 128},
+      { name: 'RSASSA-PKCS1-v1_5', saltLength: 128 },
       mock.keys.publicKey,
       mock.sigBytes,
       mock.msgBytes
@@ -124,10 +151,35 @@ describe('rsa', () => {
 
 
   cryptoMethod({
-    desc: 'encryptBytes',
+    desc: 'verify',
+    setMock: fake => window.crypto.subtle.verify = fake,
+    mockResp: true,
+    simpleReq: () => rsa.verify(
+      mock.msgStr,
+      mock.sigStr,
+      mock.keyBase64,
+      DEFAULT_CHAR_SIZE,
+      DEFAULT_HASH_ALG
+    ),
+    simpleParams: [
+      { name: 'RSASSA-PKCS1-v1_5', saltLength: 128 },
+      mock.keys.publicKey,
+      mock.sigBytes,
+      mock.msgBytes
+    ],
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'encrypt',
     setMock: fake => window.crypto.subtle.encrypt = fake,
     mockResp: mock.cipherBytes,
-    simpleReq: () => rsa.encryptBytes(mock.msgBytes, mock.keys.publicKey),
+    simpleReq: () => rsa.encrypt(
+      mock.msgBytes,
+      mock.keys.publicKey
+    ),
     simpleParams: [
       { name: 'RSA-OAEP' },
       mock.keys.publicKey,
@@ -139,10 +191,52 @@ describe('rsa', () => {
 
 
   cryptoMethod({
-    desc: 'decryptBytes',
+    desc: 'encrypt',
+    setMock: fake => window.crypto.subtle.encrypt = fake,
+    mockResp: mock.cipherBytes,
+    simpleReq: () => rsa.encrypt(
+      mock.msgStr,
+      mock.keyBase64,
+      DEFAULT_CHAR_SIZE,
+      DEFAULT_HASH_ALG
+    ),
+    simpleParams: [
+      { name: 'RSA-OAEP' },
+      mock.keys.publicKey,
+      mock.msgBytes
+    ],
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'decrypt',
     setMock: fake => window.crypto.subtle.decrypt = fake,
     mockResp: mock.msgBytes,
-    simpleReq: () => rsa.decryptBytes(mock.cipherBytes, mock.keys.privateKey),
+    simpleReq: () => rsa.decrypt(
+      mock.cipherBytes,
+      mock.keys.privateKey
+    ),
+    simpleParams: [
+      { name: 'RSA-OAEP' },
+      mock.keys.privateKey,
+      mock.cipherBytes
+    ],
+    paramChecks: [],
+    shouldThrows: []
+  })
+
+
+  cryptoMethod({
+    desc: 'decrypt',
+    setMock: fake => window.crypto.subtle.decrypt = fake,
+    mockResp: mock.msgBytes,
+    simpleReq: () => rsa.decrypt(
+      mock.cipherStr,
+      mock.keys.privateKey,
+      DEFAULT_CHAR_SIZE
+    ),
     simpleParams: [
       { name: 'RSA-OAEP' },
       mock.keys.privateKey,

--- a/test/utils/crypto.ts
+++ b/test/utils/crypto.ts
@@ -61,7 +61,6 @@ export const cryptoMethod = (opts: WebCryptoReqOpts): void => {
         await test.req()
         if(typeof test.params === 'function'){
           expect(test.params(fake.mock.calls[0])).toBeTruthy()
-
         }else {
           expect(fake.mock.calls[0]).toEqual(test.params)
         }


### PR DESCRIPTION
As we discussed earlier, I extracted the string methods from the KeyStore classes so they can be used without a KeyStore instance. My plan is to use `eccOperations.verify` and `rsaOperations.verify` to verify a string signed by a DID (in the SDK).