### PR TITLE
SubtleCrypto TS interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystore-idb",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/ecc/keys.ts
+++ b/src/ecc/keys.ts
@@ -9,7 +9,7 @@ export async function makeKeypair(
 ): Promise<CryptoKeyPair> {
   checkValidKeyUse(use)
   const alg = use === KeyUse.Read ? ECC_READ_ALG : ECC_WRITE_ALG
-  const uses =
+  const uses: KeyUsage[] =
     use === KeyUse.Read ? ['deriveKey', 'deriveBits'] : ['sign', 'verify']
   return window.crypto.subtle.generateKey(
     { name: alg, namedCurve: curve },
@@ -21,8 +21,8 @@ export async function makeKeypair(
 export async function importPublicKey(base64Key: string, curve: EccCurve, use: KeyUse): Promise<PublicKey> {
   checkValidKeyUse(use)
   const alg = use === KeyUse.Read ? ECC_READ_ALG : ECC_WRITE_ALG
-  const uses =
-    use === KeyUse.Read ? [] : ['verify']
+  const uses: KeyUsage[] =
+    use === KeyUse.Read ? [] : ['verify'] as KeyUsage[]
   const buf = utils.base64ToArrBuf(base64Key)
   return window.crypto.subtle.importKey(
     'raw',

--- a/src/ecc/keys.ts
+++ b/src/ecc/keys.ts
@@ -22,7 +22,7 @@ export async function importPublicKey(base64Key: string, curve: EccCurve, use: K
   checkValidKeyUse(use)
   const alg = use === KeyUse.Read ? ECC_READ_ALG : ECC_WRITE_ALG
   const uses: KeyUsage[] =
-    use === KeyUse.Read ? [] : ['verify'] as KeyUsage[]
+    use === KeyUse.Read ? [] : ['verify']
   const buf = utils.base64ToArrBuf(base64Key)
   return window.crypto.subtle.importKey(
     'raw',

--- a/src/rsa/keys.ts
+++ b/src/rsa/keys.ts
@@ -10,7 +10,7 @@ export async function makeKeypair(
 ): Promise<CryptoKeyPair> {
   checkValidKeyUse(use)
   const alg = use === KeyUse.Read ? RSA_READ_ALG : RSA_WRITE_ALG
-  const uses = use === KeyUse.Read ? ['encrypt', 'decrypt'] : ['sign', 'verify']
+  const uses: KeyUsage[] = use === KeyUse.Read ? ['encrypt', 'decrypt'] : ['sign', 'verify']
   return window.crypto.subtle.generateKey(
     {
       name: alg,
@@ -32,7 +32,7 @@ function stripKeyHeader(base64Key: string): string{
 export async function importPublicKey(base64Key: string, hashAlg: HashAlg, use: KeyUse): Promise<PublicKey> {
   checkValidKeyUse(use)
   const alg = use === KeyUse.Read ? RSA_READ_ALG : RSA_WRITE_ALG
-  const uses = use === KeyUse.Read ? ['encrypt'] : ['verify']
+  const uses: KeyUsage[] = use === KeyUse.Read ? ['encrypt'] : ['verify']
   const buf = utils.base64ToArrBuf(stripKeyHeader(base64Key))
   return window.crypto.subtle.importKey(
     'spki',


### PR DESCRIPTION
## Problem
Typescript updated its interface to use a `KeyUsage[]` type for key uses instead of `string[]`. This is causing the build to break with new versions of TS

## Solution
Cast uses to `KeyUsage[]`