### PR TITLE
Pass correct ctr len to aes encryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystore-idb",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/aes/operations.ts
+++ b/src/aes/operations.ts
@@ -1,6 +1,6 @@
 import keys from './keys'
 import utils from '../utils'
-import { DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants'
+import { DEFAULT_SYMM_ALG, DEFAULT_CTR_LEN } from '../constants'
 import { SymmKey, SymmKeyOpts, SymmAlg, CipherText, Msg } from '../types'
 
 export async function encryptBytes(
@@ -15,10 +15,10 @@ export async function encryptBytes(
   const cipherBuf = await window.crypto.subtle.encrypt(
     { 
       name: alg,
-      length: opts?.length || DEFAULT_SYMM_LEN,
       // AES-CTR uses a counter, AES-GCM/AES-CBC use an initialization vector
       iv: alg === SymmAlg.AES_CTR ? undefined : iv,
       counter: alg === SymmAlg.AES_CTR ? new Uint8Array(iv) : undefined,
+      length: alg === SymmAlg.AES_CTR ? DEFAULT_CTR_LEN : undefined,
     },
     importedKey,
     data
@@ -38,10 +38,10 @@ export async function decryptBytes(
   const cipherBytes = cipherText.slice(16)
   const msgBuff = await window.crypto.subtle.decrypt(
     { name: alg,
-      length: opts?.length || DEFAULT_SYMM_LEN,
       // AES-CTR uses a counter, AES-GCM/AES-CBC use an initialization vector
       iv: alg === SymmAlg.AES_CTR ? undefined : iv,
       counter: alg === SymmAlg.AES_CTR ? new Uint8Array(iv) : undefined,
+      length: alg === SymmAlg.AES_CTR ? DEFAULT_CTR_LEN : undefined,
     },
     importedKey,
     cipherBytes

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,8 +9,11 @@ export const SALT_LENGTH = 128
 export const DEFAULT_CRYPTOSYSTEM = 'ecc'
 export const DEFAULT_ECC_CURVE = EccCurve.P_256
 export const DEFAULT_RSA_SIZE = RsaSize.B2048
+
 export const DEFAULT_SYMM_ALG = SymmAlg.AES_CTR
 export const DEFAULT_SYMM_LEN = SymmKeyLength.B256
+export const DEFAULT_CTR_LEN = 64
+
 export const DEFAULT_HASH_ALG = HashAlg.SHA_256
 export const DEFAULT_CHAR_SIZE = CharSize.B16
 
@@ -28,6 +31,7 @@ export default {
   DEFAULT_ECC_CURVE,
   DEFAULT_RSA_SIZE,
   DEFAULT_SYMM_ALG,
+  DEFAULT_CTR_LEN,
   DEFAULT_HASH_ALG,
   DEFAULT_CHAR_SIZE,
   DEFAULT_STORE_NAME,

--- a/test/aes.test.ts
+++ b/test/aes.test.ts
@@ -75,7 +75,7 @@ describe('aes', () => {
         req: () => aes.encrypt(mock.msgStr, mock.keyBase64, { iv: mock.iv }),
         params: (params: any) => (
           params[0]?.name === 'AES-CTR'
-          && params[0]?.length === 256
+          && params[0]?.length === 64
           && arrBufEq(params[0]?.counter, mock.iv)
           && params[1] === mock.symmKey
           && arrBufEq(params[2], mock.msgBytes)
@@ -86,16 +86,10 @@ describe('aes', () => {
         req: () => aes.encrypt(mock.msgStr, mock.keyBase64, { alg: SymmAlg.AES_CBC, iv: mock.iv }),
         params: (params: any) => (
           params[0]?.name === 'AES-CBC'
-          && params[0]?.length === 256
           && arrBufEq(params[0]?.iv, mock.iv)
           && params[1] === mock.symmKey
           && arrBufEq(params[2], mock.msgBytes)
         )
-      },
-      {
-        desc: 'handles multiple symm key lengths',
-        req: () => aes.encrypt(mock.msgStr, mock.keyBase64, { length: SymmKeyLength.B256}),
-        params: (params: any) => params[0]?.length === 256
       }
     ],
     shouldThrows: []
@@ -117,7 +111,7 @@ describe('aes', () => {
         req: () => aes.decrypt(mock.cipherWithIVStr, mock.keyBase64),
         params: (params: any) => (
           params[0].name === 'AES-CTR'
-          && params[0].length === 256 
+          && params[0].length === 64 
           && arrBufEq(params[0].counter.buffer, mock.iv)
           && params[1] === mock.symmKey 
           && arrBufEq(params[2], mock.cipherBytes)
@@ -131,12 +125,7 @@ describe('aes', () => {
           && arrBufEq(params[0].iv, mock.iv)
           && arrBufEq(params[2], mock.cipherBytes)
         )
-      },
-      {
-        desc: 'handles multiple symm key lengths',
-        req: () => aes.decrypt(mock.cipherWithIVStr, mock.keyBase64, { length: SymmKeyLength.B256 }),
-        params: (params: any) => params[0]?.length === 256
-      },
+      }
     ],
     shouldThrows: []
   })

--- a/test/ecc.test.ts
+++ b/test/ecc.test.ts
@@ -199,7 +199,7 @@ describe('ecc', () => {
     simpleParams: [
       { name: 'AES-CTR',
         counter: new Uint8Array(16),
-        length: 256
+        length: 64
       },
       mock.symmKey,
       mock.msgBytes
@@ -216,18 +216,6 @@ describe('ecc', () => {
           { alg: SymmAlg.AES_CBC }
         ),
         params: (params: any) => params[0]?.name === 'AES-CBC'
-      },
-      {
-        desc: 'handles multiple symm key lengths',
-        req: () => ecc.encrypt(
-          mock.msgBytes,
-          mock.keys.privateKey,
-          mock.keys.publicKey,
-          DEFAULT_CHAR_SIZE,
-          DEFAULT_ECC_CURVE,
-          { length: SymmKeyLength.B256 }
-        ),
-        params: (params: any) => params[0]?.length === 256
       },
       {
         desc: 'handles an IV with AES-CTR',
@@ -276,7 +264,7 @@ describe('ecc', () => {
     simpleParams: [
       { name: 'AES-CTR',
         counter: new Uint8Array(16),
-        length: 256
+        length: 64
       },
       mock.symmKey,
       mock.msgBytes
@@ -308,7 +296,7 @@ describe('ecc', () => {
         ),
         params: (params: any) => (
           params[0].name === 'AES-CTR'
-          && params[0].length === 256
+          && params[0].length === 64
           && arrBufEq(params[0].counter.buffer, mock.iv)
           && params[1] === mock.symmKey
           && arrBufEq(params[2], mock.cipherBytes)
@@ -329,19 +317,7 @@ describe('ecc', () => {
           && arrBufEq(params[0].iv, mock.iv)
           && arrBufEq(params[2], mock.cipherBytes)
         )
-      },
-      {
-        desc: 'handles multiple symm key lengths',
-        req: () => ecc.decrypt(
-          mock.cipherWithIVBytes,
-          mock.keys.privateKey,
-          mock.keys.publicKey,
-          DEFAULT_CHAR_SIZE,
-          DEFAULT_ECC_CURVE,
-          { length: SymmKeyLength.B256 }
-        ),
-        params: (params: any) => params[0]?.length === 256
-      },
+      }
     ],
     shouldThrows: []
   })


### PR DESCRIPTION
## Problem
We were passing key length for counter size, which was fine with 128, but not with 256

## Solution
Pass a default counter length (64)