### PR TITLE
Make keystore-idb more browser friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",
     "test:prod": "npm run lint && npm run test -- --no-cache",
+    "do-publish": "yarn build && cp package.json LICENSE README.md dist/ && cd dist && npm publish",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { CharSize, Msg } from './types'
+import { Buffer } from 'buffer'
 
 export function arrBufToStr(buf: ArrayBuffer, charSize: CharSize): string {
   const arr = charSize === 8 ? new Uint8Array(buf) : new Uint16Array(buf)


### PR DESCRIPTION
* `Buffer` is not available in browsers, only in node
* `buffer` (the npm package) is a browser implementation of node's `Buffer`s. It falls back to the native implementation when used in node
* The rollup build is configured to 'inject' a `buffer` import when there's usage of `Buffer`.
* The rollup build only outputs to `index.cjs.js`, `index.es5.js` and `index.umd.js`. There's still e.g. `utils.js`, not touched by rollup.
* E.g. the file `utils.js` doesn't work in the browser, because it refers to `Buffer` without a `buffer` import.

The fix is to add the `Buffer` import to `utils.js`, now browser applications can import `keystore-idb/utils.js` and will work correctly.

It's really low effort with high impact. No-brainer IMO.
We *might* also be able to get rid of the rollup-inject plugin & simplify the rollup build a little. But I'll keep this PR as simple as possible for now.