### PR TITLE
Allow direct lib path imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+### v0.15.1
+
+Importing `keystore-idb/lib/*` directly should now work as intended. This allows bundlers to use the "real" import paths (eg. `import "keystore-idb/lib/utils.js"`) in addition to the "proxy" import paths (eg. `import "keystore-idb/utils.js"`). One reason to do this could be that you want your library to support both new and old bundlers, ie. bundlers with or without `exports` support in their `package.json` file.
+
+
 ### v0.15.0
 
 - Renamed read key to exchange key.
 - Switched out `Buffer` usage with `uint8arrays` library.
 - Built with esbuild instead of rollup.
+
 
 
 ### v0.14.0

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "keystore-idb",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "type": "module",
   "main": "lib/index.js",
   "exports": {
     ".": "./lib/index.js",
+    "./lib/*": "./lib/*",
     "./*": "./lib/*",
     "./package.json": "./package.json"
   },
@@ -15,6 +16,9 @@
     "*": {
       "lib/index.d.ts": [
         "lib/index.d.ts"
+      ],
+      "lib/*": [
+        "lib/*"
       ],
       "*": [
         "lib/*"


### PR DESCRIPTION
Copied from changelog:

> Importing `keystore-idb/lib/*` directly should now work as intended. This allows bundlers to use the "real" import paths (eg. `import "keystore-idb/lib/utils.js"`) in addition to the "proxy" import paths (eg. `import "keystore-idb/utils.js"`). One reason to do this could be that you want your library to support both new and old bundlers, ie. bundlers with or without `exports` support in their `package.json` file.