### PR TITLE
Allow AES-GCM as an algorithm & test it

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "typescript": "^4.4.2"
   },
   "dependencies": {
-    "@ungap/global-this": "^0.4.4",
     "localforage": "^1.10.0",
     "uint8arrays": "^3.0.0"
   }

--- a/src/aes/keys.ts
+++ b/src/aes/keys.ts
@@ -1,9 +1,10 @@
 import utils from '../utils.js'
 import { DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants.js'
 import { SymmKey, SymmKeyOpts } from '../types.js'
+import { webcrypto } from '../webcrypto.js'
 
 export async function makeKey(opts?: Partial<SymmKeyOpts>): Promise<SymmKey> {
-  return globalThis.crypto.subtle.generateKey(
+  return webcrypto.generateKey(
     {
       name: opts?.alg || DEFAULT_SYMM_ALG,
       length: opts?.length || DEFAULT_SYMM_LEN,
@@ -15,7 +16,7 @@ export async function makeKey(opts?: Partial<SymmKeyOpts>): Promise<SymmKey> {
 
 export async function importKey(base64key: string, opts?: Partial<SymmKeyOpts>): Promise<SymmKey> {
   const buf = utils.base64ToArrBuf(base64key)
-  return globalThis.crypto.subtle.importKey(
+  return webcrypto.importKey(
     'raw',
     buf,
     {

--- a/src/aes/operations.ts
+++ b/src/aes/operations.ts
@@ -2,6 +2,7 @@ import keys from './keys.js'
 import utils from '../utils.js'
 import { DEFAULT_SYMM_ALG, DEFAULT_CTR_LEN } from '../constants.js'
 import { SymmKey, SymmKeyOpts, SymmAlg, CipherText, Msg } from '../types.js'
+import { webcrypto } from '../webcrypto.js'
 
 export async function encryptBytes(
   msg: Msg,
@@ -12,7 +13,7 @@ export async function encryptBytes(
   const importedKey = typeof key === 'string' ? await keys.importKey(key, opts) : key
   const alg = opts?.alg || DEFAULT_SYMM_ALG
   const iv = opts?.iv || utils.randomBuf(16)
-  const cipherBuf = await globalThis.crypto.subtle.encrypt(
+  const cipherBuf = await webcrypto.encrypt(
     {
       name: alg,
       // AES-CTR uses a counter, AES-GCM/AES-CBC use an initialization vector
@@ -36,7 +37,7 @@ export async function decryptBytes(
   const alg = opts?.alg || DEFAULT_SYMM_ALG
   const iv = cipherText.slice(0, 16)
   const cipherBytes = cipherText.slice(16)
-  const msgBuff = await globalThis.crypto.subtle.decrypt(
+  const msgBuff = await webcrypto.decrypt(
     { name: alg,
       // AES-CTR uses a counter, AES-GCM/AES-CBC use an initialization vector
       iv: alg === SymmAlg.AES_CTR ? undefined : iv,
@@ -69,7 +70,7 @@ export async function decrypt(
 
 
 export async function exportKey(key: SymmKey): Promise<string> {
-  const raw = await globalThis.crypto.subtle.exportKey('raw', key)
+  const raw = await webcrypto.exportKey('raw', key)
   return utils.arrBufToBase64(raw)
 }
 

--- a/src/ecc/keys.ts
+++ b/src/ecc/keys.ts
@@ -2,6 +2,7 @@ import utils from '../utils.js'
 import { ECC_EXCHANGE_ALG, ECC_WRITE_ALG } from '../constants.js'
 import { EccCurve, KeyUse, PublicKey } from '../types.js'
 import { checkValidKeyUse } from '../errors.js'
+import { webcrypto } from '../webcrypto.js'
 
 export async function makeKeypair(
   curve: EccCurve,
@@ -11,7 +12,7 @@ export async function makeKeypair(
   const alg = use === KeyUse.Exchange ? ECC_EXCHANGE_ALG : ECC_WRITE_ALG
   const uses: KeyUsage[] =
     use === KeyUse.Exchange ? ['deriveKey', 'deriveBits'] : ['sign', 'verify']
-  return globalThis.crypto.subtle.generateKey(
+  return webcrypto.generateKey(
     { name: alg, namedCurve: curve },
     false,
     uses
@@ -24,7 +25,7 @@ export async function importPublicKey(base64Key: string, curve: EccCurve, use: K
   const uses: KeyUsage[] =
     use === KeyUse.Exchange ? [] : ['verify']
   const buf = utils.base64ToArrBuf(base64Key)
-  return globalThis.crypto.subtle.importKey(
+  return webcrypto.importKey(
     'raw',
     buf,
     { name: alg, namedCurve: curve },

--- a/src/ecc/operations.ts
+++ b/src/ecc/operations.ts
@@ -3,6 +3,7 @@ import keys from './keys.js'
 import utils, { normalizeBase64ToBuf, normalizeUnicodeToBuf } from '../utils.js'
 import { DEFAULT_CHAR_SIZE, DEFAULT_ECC_CURVE, DEFAULT_HASH_ALG, ECC_EXCHANGE_ALG, ECC_WRITE_ALG, DEFAULT_SYMM_ALG, DEFAULT_SYMM_LEN } from '../constants.js'
 import { CharSize, EccCurve, Msg, PrivateKey, PublicKey, HashAlg, KeyUse, SymmKey, SymmKeyOpts } from '../types.js'
+import { webcrypto } from '../webcrypto.js'
 
 
 export async function sign(
@@ -11,7 +12,7 @@ export async function sign(
   charSize: CharSize = DEFAULT_CHAR_SIZE,
   hashAlg: HashAlg = DEFAULT_HASH_ALG,
 ): Promise<ArrayBuffer> {
-  return globalThis.crypto.subtle.sign(
+  return webcrypto.sign(
     { name: ECC_WRITE_ALG, hash: { name: hashAlg }},
     privateKey,
     normalizeUnicodeToBuf(msg, charSize)
@@ -26,7 +27,7 @@ export async function verify(
   curve: EccCurve = DEFAULT_ECC_CURVE,
   hashAlg: HashAlg = DEFAULT_HASH_ALG
 ): Promise<boolean> {
-  return globalThis.crypto.subtle.verify(
+  return webcrypto.verify(
     { name: ECC_WRITE_ALG, hash: { name: hashAlg }},
     typeof publicKey === "string"
       ? await keys.importPublicKey(publicKey, curve, KeyUse.Write)
@@ -68,12 +69,12 @@ export async function decrypt(
 }
 
 export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {
-  const raw = await globalThis.crypto.subtle.exportKey('raw', keypair.publicKey as PublicKey)
+  const raw = await webcrypto.exportKey('raw', keypair.publicKey as PublicKey)
   return utils.arrBufToBase64(raw)
 }
 
 export async function getSharedKey(privateKey: PrivateKey, publicKey: PublicKey, opts?: Partial<SymmKeyOpts>): Promise<SymmKey> {
-  return globalThis.crypto.subtle.deriveKey(
+  return webcrypto.deriveKey(
     { name: ECC_EXCHANGE_ALG, public: publicKey },
     privateKey,
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import "@ungap/global-this"
 import { init, clear } from './keystore/index.js'
 
 import * as ecc from './ecc/index.js'

--- a/src/rsa/keys.ts
+++ b/src/rsa/keys.ts
@@ -2,6 +2,7 @@ import { RSA_EXCHANGE_ALG, RSA_WRITE_ALG } from '../constants.js'
 import { RsaSize, HashAlg, KeyUse, PublicKey } from '../types.js'
 import utils from '../utils.js'
 import { checkValidKeyUse } from '../errors.js'
+import { webcrypto } from '../webcrypto.js'
 
 export async function makeKeypair(
   size: RsaSize,
@@ -11,7 +12,7 @@ export async function makeKeypair(
   checkValidKeyUse(use)
   const alg = use === KeyUse.Exchange ? RSA_EXCHANGE_ALG : RSA_WRITE_ALG
   const uses: KeyUsage[] = use === KeyUse.Exchange ? ['encrypt', 'decrypt'] : ['sign', 'verify']
-  return globalThis.crypto.subtle.generateKey(
+  return webcrypto.generateKey(
     {
       name: alg,
       modulusLength: size,
@@ -34,7 +35,7 @@ export async function importPublicKey(base64Key: string, hashAlg: HashAlg, use: 
   const alg = use === KeyUse.Exchange ? RSA_EXCHANGE_ALG : RSA_WRITE_ALG
   const uses: KeyUsage[] = use === KeyUse.Exchange ? ['encrypt'] : ['verify']
   const buf = utils.base64ToArrBuf(stripKeyHeader(base64Key))
-  return globalThis.crypto.subtle.importKey(
+  return webcrypto.importKey(
     'spki',
     buf,
     { name: alg, hash: {name: hashAlg}},

--- a/src/rsa/operations.ts
+++ b/src/rsa/operations.ts
@@ -2,6 +2,7 @@ import keys from './keys.js'
 import utils, { normalizeBase64ToBuf, normalizeUnicodeToBuf } from '../utils.js'
 import { DEFAULT_CHAR_SIZE, DEFAULT_HASH_ALG, RSA_EXCHANGE_ALG, RSA_WRITE_ALG, SALT_LENGTH } from '../constants.js'
 import { CharSize, HashAlg, KeyUse, Msg, PrivateKey, PublicKey } from '../types.js'
+import { webcrypto } from '../webcrypto.js'
 
 
 export async function sign(
@@ -9,7 +10,7 @@ export async function sign(
   privateKey: PrivateKey,
   charSize: CharSize = DEFAULT_CHAR_SIZE
 ): Promise<ArrayBuffer> {
-  return globalThis.crypto.subtle.sign(
+  return webcrypto.sign(
     { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
     privateKey,
     normalizeUnicodeToBuf(msg, charSize)
@@ -23,7 +24,7 @@ export async function verify(
   charSize: CharSize = DEFAULT_CHAR_SIZE,
   hashAlg: HashAlg = DEFAULT_HASH_ALG
 ): Promise<boolean> {
-  return globalThis.crypto.subtle.verify(
+  return webcrypto.verify(
     { name: RSA_WRITE_ALG, saltLength: SALT_LENGTH },
     typeof publicKey === "string"
       ? await keys.importPublicKey(publicKey, hashAlg, KeyUse.Write)
@@ -39,7 +40,7 @@ export async function encrypt(
   charSize: CharSize = DEFAULT_CHAR_SIZE,
   hashAlg: HashAlg = DEFAULT_HASH_ALG
 ): Promise<ArrayBuffer> {
-  return globalThis.crypto.subtle.encrypt(
+  return webcrypto.encrypt(
     { name: RSA_EXCHANGE_ALG },
     typeof publicKey === "string"
       ? await keys.importPublicKey(publicKey, hashAlg, KeyUse.Exchange)
@@ -53,7 +54,7 @@ export async function decrypt(
   privateKey: PrivateKey
 ): Promise<ArrayBuffer> {
   const normalized = normalizeBase64ToBuf(msg)
-  return globalThis.crypto.subtle.decrypt(
+  return webcrypto.decrypt(
     { name: RSA_EXCHANGE_ALG },
     privateKey,
     normalized
@@ -61,7 +62,7 @@ export async function decrypt(
 }
 
 export async function getPublicKey(keypair: CryptoKeyPair): Promise<string> {
-  const spki = await globalThis.crypto.subtle.exportKey('spki', keypair.publicKey as PublicKey)
+  const spki = await webcrypto.exportKey('spki', keypair.publicKey as PublicKey)
   return utils.arrBufToBase64(spki)
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export enum RsaSize {
 export enum SymmAlg {
   AES_CTR = 'AES-CTR',
   AES_CBC = 'AES-CBC',
+  AES_GCM = 'AES-GCM',
 }
 
 export enum SymmKeyLength {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import * as uint8arrays from 'uint8arrays'
 import { CharSize, Msg } from './types.js'
+import { crypto } from './webcrypto.js'
 
 
 export function arrBufToStr(buf: ArrayBuffer, charSize: CharSize): string {
@@ -32,7 +33,7 @@ export function publicExponent(): Uint8Array {
 
 export function randomBuf(length: number): ArrayBuffer {
   const arr = new Uint8Array(length)
-  globalThis.crypto.getRandomValues(arr)
+  crypto.getRandomValues(arr)
   return arr.buffer
 }
 

--- a/src/webcrypto.ts
+++ b/src/webcrypto.ts
@@ -1,0 +1,7 @@
+export const crypto: Crypto = (globalThis.crypto as any).webcrypto || globalThis.crypto
+
+if (crypto == null || crypto.subtle == null) {
+  throw new Error("keystore-idb: Couldn't find access to the WebCrypto API on this platform.")
+}
+
+export const webcrypto: SubtleCrypto = crypto.subtle

--- a/test/aes.test.ts
+++ b/test/aes.test.ts
@@ -1,13 +1,14 @@
 import aes from '../src/aes'
 import utils from '../src/utils'
 import { SymmAlg, SymmKeyLength } from '../src/types'
+import { crypto, webcrypto } from '../src/webcrypto'
 import { mock, cryptoMethod, arrBufEq } from './utils'
 
 describe('aes', () => {
 
   cryptoMethod({
     desc: 'makeKey',
-    setMock: fake => globalThis.crypto.subtle.generateKey = fake,
+    setMock: fake => webcrypto.generateKey = fake,
     mockResp: mock.symmKey,
     simpleReq: () => aes.makeKey(),
     simpleParams: [
@@ -38,7 +39,7 @@ describe('aes', () => {
 
   cryptoMethod({
     desc: 'importKey',
-    setMock: fake => globalThis.crypto.subtle.importKey = fake,
+    setMock: fake => webcrypto.importKey = fake,
     mockResp: mock.symmKey,
     simpleReq: () => aes.importKey(mock.keyBase64),
     simpleParams: [
@@ -67,9 +68,9 @@ describe('aes', () => {
   cryptoMethod({
     desc: 'encrypt',
     setMock: fake => {
-      globalThis.crypto.subtle.encrypt = fake
-      globalThis.crypto.subtle.importKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
-      globalThis.crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
+      webcrypto.encrypt = fake
+      webcrypto.importKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+      crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
     },
     mockResp: mock.cipherBytes,
     expectedResp: mock.cipherWithIVStr,
@@ -104,8 +105,8 @@ describe('aes', () => {
   cryptoMethod({
     desc: 'decrypt',
     setMock: fake => {
-      globalThis.crypto.subtle.decrypt = fake
-      globalThis.crypto.subtle.importKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+      webcrypto.decrypt = fake
+      webcrypto.importKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
     },
     mockResp: mock.msgBytes,
     expectedResp: mock.msgStr,
@@ -138,7 +139,7 @@ describe('aes', () => {
 
   cryptoMethod({
     desc: 'exportKey',
-    setMock: fake => globalThis.crypto.subtle.exportKey = fake,
+    setMock: fake => webcrypto.exportKey = fake,
     mockResp: utils.base64ToArrBuf(mock.keyBase64),
     expectedResp: mock.keyBase64,
     simpleReq: () => aes.exportKey(mock.symmKey),

--- a/test/aes.test.ts
+++ b/test/aes.test.ts
@@ -22,6 +22,11 @@ describe('aes', () => {
         params: (params: any) => params[0]?.name === 'AES-CBC'
       },
       {
+        desc: 'handles multiple key algorithms',
+        req: () => aes.makeKey({ alg: SymmAlg.AES_GCM }),
+        params: (params: any) => params[0]?.name === 'AES-GCM'
+      },
+      {
         desc: 'handles multiple key lengths',
         req: () => aes.makeKey({ length: SymmKeyLength.B256 }),
         params: (params: any) => params[0]?.length === 256

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,7 @@
 import config from '../src/config'
 import { CryptoSystem, SymmAlg, SymmKeyLength } from '../src/types'
 import utils from '../src/utils'
+import { webcrypto } from '../src/webcrypto'
 import { mock } from './utils'
 
 describe('config', () => {
@@ -16,7 +17,7 @@ describe('config', () => {
         fakeClone.mockResolvedValue(undefined)
 
         fakeMake = jest.fn(() => new Promise(r => r(mock.keys)))
-        globalThis.crypto.subtle.generateKey = fakeMake
+        webcrypto.generateKey = fakeMake
 
         response = await config.eccEnabled()
       })
@@ -42,7 +43,7 @@ describe('config', () => {
         )
 
         fakeMake = jest.fn(() => new Promise(r => r(mock.keys)))
-        globalThis.crypto.subtle.generateKey = fakeMake
+        webcrypto.generateKey = fakeMake
 
         response = await config.eccEnabled()
       })

--- a/test/ecc.test.ts
+++ b/test/ecc.test.ts
@@ -3,13 +3,14 @@ import errors from '../src/errors'
 import utils from '../src/utils'
 import { DEFAULT_CHAR_SIZE, DEFAULT_ECC_CURVE } from '../src/constants'
 import { KeyUse, EccCurve, HashAlg, SymmAlg, SymmKeyLength } from '../src/types'
+import { crypto, webcrypto } from '../src/webcrypto'
 import { mock, cryptoMethod, arrBufEq } from './utils'
 
 describe('ecc', () => {
 
   cryptoMethod({
     desc: 'makeKeypair',
-    setMock: fake => globalThis.crypto.subtle.generateKey = fake,
+    setMock: fake => webcrypto.generateKey = fake,
     mockResp: mock.keys,
     simpleReq: () => ecc.makeKeypair(EccCurve.P_256, KeyUse.Exchange),
     simpleParams: [
@@ -45,7 +46,7 @@ describe('ecc', () => {
 
   cryptoMethod({
     desc: 'importPublicExchangeKey',
-    setMock: fake => globalThis.crypto.subtle.importKey = fake,
+    setMock: fake => webcrypto.importKey = fake,
     mockResp: mock.keys.publicKey,
     expectedResp: mock.keys.publicKey,
     simpleReq: () => ecc.importPublicKey(mock.keyBase64, EccCurve.P_256, KeyUse.Exchange),
@@ -80,7 +81,7 @@ describe('ecc', () => {
 
   cryptoMethod({
     desc: 'sign',
-    setMock: fake => globalThis.crypto.subtle.sign = fake,
+    setMock: fake => webcrypto.sign = fake,
     mockResp: mock.sigBytes,
     simpleReq: () => ecc.sign(
       mock.msgBytes,
@@ -109,7 +110,7 @@ describe('ecc', () => {
 
   cryptoMethod({
     desc: 'sign',
-    setMock: fake => globalThis.crypto.subtle.sign = fake,
+    setMock: fake => webcrypto.sign = fake,
     mockResp: mock.sigBytes,
     simpleReq: () => ecc.sign(
       mock.msgStr,
@@ -129,7 +130,7 @@ describe('ecc', () => {
 
   cryptoMethod({
     desc: 'verify',
-    setMock: fake => globalThis.crypto.subtle.verify = fake,
+    setMock: fake => webcrypto.verify = fake,
     mockResp: true,
     simpleReq: () => ecc.verify(
       mock.msgBytes,
@@ -162,7 +163,7 @@ describe('ecc', () => {
 
   cryptoMethod({
     desc: 'verify',
-    setMock: fake => globalThis.crypto.subtle.verify = fake,
+    setMock: fake => webcrypto.verify = fake,
     mockResp: true,
     simpleReq: () => ecc.verify(
       mock.msgStr,
@@ -186,9 +187,9 @@ describe('ecc', () => {
   cryptoMethod({
     desc: 'encrypt',
     setMock: fake => {
-      globalThis.crypto.subtle.encrypt = fake
-      globalThis.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
-      globalThis.crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
+      webcrypto.encrypt = fake
+      webcrypto.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+      crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
     },
     mockResp: mock.cipherBytes,
     simpleReq: () => ecc.encrypt(
@@ -249,9 +250,9 @@ describe('ecc', () => {
   cryptoMethod({
     desc: 'encrypt',
     setMock: fake => {
-      globalThis.crypto.subtle.encrypt = fake
-      globalThis.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
-      globalThis.crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
+      webcrypto.encrypt = fake
+      webcrypto.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+      crypto.getRandomValues = jest.fn(() => new Promise(r => r(new Uint8Array(16)))) as any
     },
     mockResp: mock.cipherBytes,
     simpleReq: () => ecc.encrypt(
@@ -277,8 +278,8 @@ describe('ecc', () => {
   cryptoMethod({
     desc: 'decrypt',
     setMock: fake => {
-      globalThis.crypto.subtle.decrypt = fake
-      globalThis.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+      webcrypto.decrypt = fake
+      webcrypto.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
     },
     mockResp: mock.msgBytes,
     simpleReq: () => ecc.decrypt(
@@ -325,8 +326,8 @@ describe('ecc', () => {
   cryptoMethod({
     desc: 'decrypt',
     setMock: fake => {
-      globalThis.crypto.subtle.decrypt = fake
-      globalThis.crypto.subtle.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
+      webcrypto.decrypt = fake
+      webcrypto.deriveKey = jest.fn(() => new Promise(r => r(mock.symmKey)))
     },
     mockResp: mock.msgBytes,
     simpleReq: () => ecc.decrypt(
@@ -342,7 +343,7 @@ describe('ecc', () => {
 
   cryptoMethod({
     desc: 'getPublicKey',
-    setMock: fake => globalThis.crypto.subtle.exportKey = fake,
+    setMock: fake => webcrypto.exportKey = fake,
     mockResp: utils.base64ToArrBuf(mock.keyBase64),
     expectedResp: mock.keyBase64,
     simpleReq: () => ecc.getPublicKey(mock.keys),
@@ -357,7 +358,7 @@ describe('ecc', () => {
 
   cryptoMethod({
     desc: 'getSharedKey',
-    setMock: fake => globalThis.crypto.subtle.deriveKey = fake,
+    setMock: fake => webcrypto.deriveKey = fake,
     mockResp: mock.symmKey,
     simpleReq: () => ecc.getSharedKey(mock.keys.privateKey, mock.keys.publicKey),
     simpleParams: [

--- a/test/rsa.test.ts
+++ b/test/rsa.test.ts
@@ -4,12 +4,13 @@ import utils from '../src/utils'
 import { DEFAULT_CHAR_SIZE, DEFAULT_HASH_ALG } from '../src/constants'
 import { KeyUse, RsaSize, HashAlg } from '../src/types'
 import { mock, cryptoMethod } from './utils'
+import { webcrypto } from '../src/webcrypto'
 
 describe('rsa', () => {
 
   cryptoMethod({
     desc: 'makeKeypair',
-    setMock: fake => globalThis.crypto.subtle.generateKey = fake,
+    setMock: fake => webcrypto.generateKey = fake,
     mockResp: mock.keys,
     simpleReq: () => rsa.makeKeypair(RsaSize.B2048, HashAlg.SHA_256, KeyUse.Exchange),
     simpleParams: [
@@ -60,7 +61,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'importPublicExchangeKey',
-    setMock: fake => globalThis.crypto.subtle.importKey = fake,
+    setMock: fake => webcrypto.importKey = fake,
     mockResp: mock.keys.publicKey,
     expectedResp: mock.keys.publicKey,
     simpleReq: () => rsa.importPublicKey(mock.keyBase64, HashAlg.SHA_256, KeyUse.Exchange),
@@ -95,7 +96,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'sign',
-    setMock: fake => globalThis.crypto.subtle.sign = fake,
+    setMock: fake => webcrypto.sign = fake,
     mockResp: mock.sigBytes,
     simpleReq: () => rsa.sign(
       mock.msgBytes,
@@ -113,7 +114,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'sign',
-    setMock: fake => globalThis.crypto.subtle.sign = fake,
+    setMock: fake => webcrypto.sign = fake,
     mockResp: mock.sigBytes,
     simpleReq: () => rsa.sign(
       mock.msgStr,
@@ -132,7 +133,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'verify',
-    setMock: fake => globalThis.crypto.subtle.verify = fake,
+    setMock: fake => webcrypto.verify = fake,
     mockResp: true,
     simpleReq: () => rsa.verify(
       mock.msgBytes,
@@ -152,7 +153,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'verify',
-    setMock: fake => globalThis.crypto.subtle.verify = fake,
+    setMock: fake => webcrypto.verify = fake,
     mockResp: true,
     simpleReq: () => rsa.verify(
       mock.msgStr,
@@ -174,7 +175,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'encrypt',
-    setMock: fake => globalThis.crypto.subtle.encrypt = fake,
+    setMock: fake => webcrypto.encrypt = fake,
     mockResp: mock.cipherBytes,
     simpleReq: () => rsa.encrypt(
       mock.msgBytes,
@@ -192,7 +193,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'encrypt',
-    setMock: fake => globalThis.crypto.subtle.encrypt = fake,
+    setMock: fake => webcrypto.encrypt = fake,
     mockResp: mock.cipherBytes,
     simpleReq: () => rsa.encrypt(
       mock.msgStr,
@@ -212,7 +213,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'decrypt',
-    setMock: fake => globalThis.crypto.subtle.decrypt = fake,
+    setMock: fake => webcrypto.decrypt = fake,
     mockResp: mock.msgBytes,
     simpleReq: () => rsa.decrypt(
       mock.cipherBytes,
@@ -230,7 +231,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'decrypt',
-    setMock: fake => globalThis.crypto.subtle.decrypt = fake,
+    setMock: fake => webcrypto.decrypt = fake,
     mockResp: mock.msgBytes,
     simpleReq: () => rsa.decrypt(
       mock.cipherStr,
@@ -248,7 +249,7 @@ describe('rsa', () => {
 
   cryptoMethod({
     desc: 'getPublicKey',
-    setMock: fake => globalThis.crypto.subtle.exportKey = fake,
+    setMock: fake => webcrypto.exportKey = fake,
     mockResp: utils.base64ToArrBuf(mock.keyBase64),
     expectedResp: mock.keyBase64,
     simpleReq: () => rsa.getPublicKey(mock.keys),

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,11 +811,6 @@
     "@typescript-eslint/types" "4.31.0"
     eslint-visitor-keys "^2.0.0"
 
-"@ungap/global-this@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@ungap/global-this/-/global-this-0.4.4.tgz#8a1b2cfcd3e26e079a847daba879308c924dd695"
-  integrity sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==
-
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"


### PR DESCRIPTION
First part is basically just to allow AES-GCM in the types of keystore-idb and expand one test to allow this parameter.

The second part allows us to use keystore-idb's indexeddb-independent parts (e.g. the aes module) in node without having to monkey-patch `globalThis`.

Unfortunately, while that allows us to run some parts of keystore-idb *in node*, it doesn't yet work *in jest*, which spins up its own environment, which doesn't support webcrypto. More figuring out needed to get that working.