### PR TITLE
Pseudo-random Value Generation with Rejection Sampling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.15.5
+
+- Support a `max` parameter (based on rejection sampling) in `randomBuf` rng.
+
 ### v0.15.4
 
 - Bump one-webcrypto to 1.0.3 for wider bundler support.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -30,11 +30,6 @@ module.exports = {
     "src/**/*.{js,ts}"
   ],
   globals: {
-    globalThis: {
-      crypto: {
-        subtle: {}
-      }
-    },
     localForage: {}
   },
   restoreMocks: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystore-idb",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "In-browser key management with IndexedDB and the Web Crypto API",
   "keywords": [],
   "type": "module",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,18 +6,19 @@ export const NotKey = new Error("Retrieved an asymmetric keypair when an symmetr
 export const ECCNotEnabled = new Error("ECC is not enabled for this browser. Please use RSA instead.")
 export const UnsupportedCrypto = new Error("Cryptosystem not supported. Please use ECC or RSA")
 export const InvalidKeyUse = new Error("Invalid key use. Please use 'exchange' or 'write")
+export const InvalidMaxValue = Error("Max must be less than 256")
 
 export function checkIsKeyPair(keypair: any): CryptoKeyPair {
-  if(!keypair || keypair === null) {
+  if (!keypair || keypair === null) {
     throw KeyDoesNotExist
-  } else if(keypair.privateKey === undefined) {
+  } else if (keypair.privateKey === undefined) {
     throw NotKeyPair
   }
   return keypair as CryptoKeyPair
 }
 
 export function checkIsKey(key: any): CryptoKey {
-  if(!key || key === null) {
+  if (!key || key === null) {
     throw KeyDoesNotExist
   } else if (key.privateKey !== undefined || key.algorithm === undefined) {
     throw NotKey
@@ -35,7 +36,7 @@ export function checkValidKeyUse(use: KeyUse): void {
 
 function checkValid<T>(toCheck: T, opts: T[], error: Error): void {
   const match = opts.some(opt => opt === toCheck)
-  if(!match) {
+  if (!match) {
     throw error
   }
 }
@@ -51,4 +52,5 @@ export default {
   checkIsKey,
   checkValidCryptoSystem,
   checkValidKeyUse,
+  InvalidMaxValue,
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,7 +6,7 @@ export const NotKey = new Error("Retrieved an asymmetric keypair when an symmetr
 export const ECCNotEnabled = new Error("ECC is not enabled for this browser. Please use RSA instead.")
 export const UnsupportedCrypto = new Error("Cryptosystem not supported. Please use ECC or RSA")
 export const InvalidKeyUse = new Error("Invalid key use. Please use 'exchange' or 'write")
-export const InvalidMaxValue = Error("Max must be less than 256")
+export const InvalidMaxValue = new Error("Max must be less than 256 and greater than 0")
 
 export function checkIsKeyPair(keypair: any): CryptoKeyPair {
   if (!keypair || keypair === null) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export function publicExponent(): Uint8Array {
   return new Uint8Array([0x01, 0x00, 0x01])
 }
 
-export function randomBuf(length: number, max = 255): ArrayBuffer {
+export function randomBuf(length: number, { max }: { max: number } = { max: 255 }): ArrayBuffer {
   if (max < 1 || max > 255) {
     throw errors.InvalidMaxValue
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function publicExponent(): Uint8Array {
 }
 
 export function randomBuf(length: number, max = 255): ArrayBuffer {
-  if (max > 255) {
+  if (max < 1 || max > 255) {
     throw errors.InvalidMaxValue
   }
 
@@ -45,11 +45,14 @@ export function randomBuf(length: number, max = 255): ArrayBuffer {
   }
 
   let index = 0
+  const interval = max + 1
+  const divisibleMax = Math.floor(256 / interval) * interval
   const tmp = new Uint8Array(1)
+
   while (index < arr.length) {
     webcrypto.getRandomValues(tmp)
-    if (tmp[0] <= max) {
-      arr[index] = tmp[0]
+    if (tmp[0] < divisibleMax) {
+      arr[index] = tmp[0] % interval
       index++
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { webcrypto } from 'one-webcrypto'
 import * as uint8arrays from 'uint8arrays'
+import errors from './errors.js'
 import { CharSize, Msg } from './types.js'
 
 
@@ -33,7 +34,7 @@ export function publicExponent(): Uint8Array {
 
 export function randomBuf(length: number, max = 255): ArrayBuffer {
   if (max > 255) {
-    throw new Error("max must be less than 256")
+    throw errors.InvalidMaxValue
   }
 
   const arr = new Uint8Array(length)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,9 +31,28 @@ export function publicExponent(): Uint8Array {
   return new Uint8Array([0x01, 0x00, 0x01])
 }
 
-export function randomBuf(length: number): ArrayBuffer {
+export function randomBuf(length: number, max = 255): ArrayBuffer {
+  if (max > 255) {
+    throw new Error("max must be less than 256")
+  }
+
   const arr = new Uint8Array(length)
-  webcrypto.getRandomValues(arr)
+
+  if (max == 255) {
+    webcrypto.getRandomValues(arr)
+    return arr.buffer
+  }
+
+  let index = 0
+  const tmp = new Uint8Array(1)
+  while (index < arr.length) {
+    webcrypto.getRandomValues(tmp)
+    if (tmp[0] <= max) {
+      arr[index] = tmp[0]
+      index++
+    }
+  }
+
   return arr.buffer
 }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -7,7 +7,7 @@ describe('utils', () => {
     const max = 10
 
     for (let i = 0; i < 1000; i++) {
-      const byte = new Uint8Array(utils.randomBuf(1, max))[0]
+      const byte = new Uint8Array(utils.randomBuf(1, { max }))[0]
       if (byte > max) {
         hasAboveMax = true
         break
@@ -19,21 +19,19 @@ describe('utils', () => {
 
   it('returns ArrayBuffer of specified length', async () => {
     const buf1 = new Uint8Array(utils.randomBuf(2))
-    const buf2 = new Uint8Array(utils.randomBuf(45, 15))
-
-    console.log(">>>>>", buf1, buf2)
+    const buf2 = new Uint8Array(utils.randomBuf(45, { max: 15 }))
 
     expect(buf1.length).toBe(2)
     expect(buf2.length).toBe(45)
   })
 
   it('does not support max values above 255', async () => {
-    const fn = () => utils.randomBuf(1, 256)
+    const fn = () => utils.randomBuf(1, { max: 256 })
     expect(fn).toThrow(errors.InvalidMaxValue)
   })
 
   it('does not support max values below 1', async () => {
-    const fn = () => utils.randomBuf(1, -20)
+    const fn = () => utils.randomBuf(1, { max: -20 })
     expect(fn).toThrow(errors.InvalidMaxValue)
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -21,12 +21,19 @@ describe('utils', () => {
     const buf1 = new Uint8Array(utils.randomBuf(2))
     const buf2 = new Uint8Array(utils.randomBuf(45, 15))
 
+    console.log(">>>>>", buf1, buf2)
+
     expect(buf1.length).toBe(2)
     expect(buf2.length).toBe(45)
   })
 
   it('does not support max values above 255', async () => {
     const fn = () => utils.randomBuf(1, 256)
+    expect(fn).toThrow(errors.InvalidMaxValue)
+  })
+
+  it('does not support max values below 1', async () => {
+    const fn = () => utils.randomBuf(1, -20)
     expect(fn).toThrow(errors.InvalidMaxValue)
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,32 @@
+import errors from '../src/errors'
+import utils from '../src/utils'
+
+describe('utils', () => {
+  it('uses rejection sampling to generate ', async () => {
+    let hasAboveMax = false
+    const max = 10
+
+    for (let i = 0; i < 1000; i++) {
+      const byte = new Uint8Array(utils.randomBuf(1, max))[0]
+      if (byte > max) {
+        hasAboveMax = true
+        break
+      }
+    }
+
+    expect(hasAboveMax).toBe(false)
+  })
+
+  it('returns ArrayBuffer of specified length', async () => {
+    const buf1 = new Uint8Array(utils.randomBuf(2))
+    const buf2 = new Uint8Array(utils.randomBuf(45, 15))
+
+    expect(buf1.length).toBe(2)
+    expect(buf2.length).toBe(45)
+  })
+
+  it('does not support max values above 255', async () => {
+    const fn = () => utils.randomBuf(1, 256)
+    expect(fn).toThrow(errors.InvalidMaxValue)
+  })
+})


### PR DESCRIPTION
## Summary

This PR implements the following **feature**

* [x] Support pseudo-random value generation with rejection sampling 

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

`randomBuf` function can only generate values between `[0-255]`. This PR extends randomBuf to support rejection sampling given a max parameter.

## Test plan (required)

```bash
yarn test -t "utils"
```
